### PR TITLE
feat: エンコーディングの判定処理をAPIに変更 #13

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -57,7 +57,7 @@ jobs:
         with:
           node-version-file: ./.node-version
       - run: npm install
-      - run: xvfb-run -a npm test -- --minimum-vscode-version 1.66.0
+      - run: xvfb-run -a npm test -- --minimum-vscode-version 1.100.0
         if: runner.os == 'Linux'
-      - run: npm test -- --minimum-vscode-version 1.66.0
+      - run: npm test -- --minimum-vscode-version 1.100.0
         if: runner.os != 'Linux'

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,13 @@
       "name": "wave-dash-unify",
       "version": "0.3.2",
       "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "encoding-japanese": "^2.2.0"
-      },
       "devDependencies": {
         "@types/encoding-japanese": "^2.2.1",
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.10",
         "@types/node": "22.x",
         "@types/tmp": "^0.2.6",
-        "@types/vscode": "^1.66.0",
+        "@types/vscode": "^1.100.0",
         "@types/yargs": "^17.0.33",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "@typescript-eslint/parser": "^5.62.0",
@@ -37,7 +34,7 @@
         "yargs": "^17.7.2"
       },
       "engines": {
-        "vscode": "^1.66.0"
+        "vscode": "^1.100.0"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -1102,10 +1099,11 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.99.1",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.99.1.tgz",
-      "integrity": "sha512-cQlqxHZ040ta6ovZXnXRxs3fJiTmlurkIWOfZVcLSZPcm9J4ikFpXuB7gihofGn5ng+kDVma5EmJIclfk0trPQ==",
-      "dev": true
+      "version": "1.100.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.100.0.tgz",
+      "integrity": "sha512-4uNyvzHoraXEeCamR3+fzcBlh7Afs4Ifjs4epINyUX/jvdk0uzLnwiDY35UKDKnkCHP5Nu3dljl2H8lR6s+rQw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -2932,14 +2930,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "dev": true
-    },
-    "node_modules/encoding-japanese": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
-      "integrity": "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A==",
-      "engines": {
-        "node": ">=8.10.0"
-      }
     },
     "node_modules/encoding-sniffer": {
       "version": "0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.3.2",
       "license": "SEE LICENSE IN LICENSE",
       "devDependencies": {
-        "@types/encoding-japanese": "^2.2.1",
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.10",
         "@types/node": "22.x",
@@ -1016,12 +1015,6 @@
       "engines": {
         "node": ">=14"
       }
-    },
-    "node_modules/@types/encoding-japanese": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@types/encoding-japanese/-/encoding-japanese-2.2.1.tgz",
-      "integrity": "sha512-6jjepuTusvySxMLP7W6usamlbgf0F4sIDvm7EzYePjLHY7zWUv4yz2PLUnu0vuNVtXOTLu2cRdFcDg40J5Owsw==",
-      "dev": true
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "spellcheck": "cspell ."
   },
   "devDependencies": {
-    "@types/encoding-japanese": "^2.2.1",
     "@types/glob": "^8.1.0",
     "@types/mocha": "^10.0.10",
     "@types/node": "22.x",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "0.3.2",
   "publisher": "yutotnh",
   "engines": {
-    "vscode": "^1.66.0"
+    "vscode": "^1.100.0"
   },
   "categories": [
     "Other"
@@ -85,7 +85,7 @@
     "@types/mocha": "^10.0.10",
     "@types/node": "22.x",
     "@types/tmp": "^0.2.6",
-    "@types/vscode": "^1.66.0",
+    "@types/vscode": "^1.100.0",
     "@types/yargs": "^17.0.33",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "@typescript-eslint/parser": "^5.62.0",
@@ -103,8 +103,5 @@
     "webpack": "^5.99.8",
     "webpack-cli": "^6.0.1",
     "yargs": "^17.7.2"
-  },
-  "dependencies": {
-    "encoding-japanese": "^2.2.0"
   }
 }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -185,86 +185,25 @@ suite("Extension Test Suite", () => {
    * 文字列がEUC-JPかを判定する関数をテストする
    */
   test("detect EUC-JP", async () => {
-    const eucjpContents = [
-      // 全角チルダのみ
-      // 文字列: "～"
-      Buffer.from([0x8f, 0xa2, 0xb7]),
-      // 文字列: "～～"
-      Buffer.from([0x8f, 0xa2, 0xb7, 0x8f, 0xa2, 0xb7]),
-
-      // 全角チルダの前にASCII文字
-      // 文字列: "1～～"
-      Buffer.from([0xad, 0xa1]),
-
-      // CP51932のテキスト
-      // 文字列: 髙
-      Buffer.from([0xfc, 0xe2, 0x0a]),
-
-      // CP51932のテキスト
-      // 文字列: ①
-      Buffer.from([0xad, 0xa1]),
-    ];
-
-    eucjpContents.forEach((content) => {
-      assert.strictEqual(
-        extension.isEUCJP(content),
-        true,
-        `content: ${content.toString("hex")}`,
-      );
+    const eucjpDocument = await vscode.workspace.openTextDocument({
+      content: "あ", // 文字列は何でも良い
+      encoding: "eucjp",
     });
+    assert.strictEqual(
+      extension.isEUCJP(eucjpDocument),
+      true,
+      `document: ${eucjpDocument.getText()}`,
+    );
 
-    const notEucjpContents = [
-      // ASCIIのみのテキストはEUC-JPと判断されるため、テストしない
-      // 文字列: 123
-      // Buffer.from([0x31, 0x32, 0x33]),
-
-      // Shift-JISのテキスト
-      // 文字列: こんにちは
-      Buffer.from([0x82, 0xb1, 0x82, 0xf1, 0x82, 0xc9, 0x82, 0xbf, 0x82, 0xcd]),
-
-      // UTF-8のテキスト
-      // 文字列: よろしく
-      Buffer.from([
-        0xe3, 0x82, 0x88, 0xe3, 0x82, 0x8d, 0xe3, 0x81, 0x97, 0xe3, 0x81, 0x8f,
-      ]),
-    ];
-
-    notEucjpContents.forEach((content) => {
-      assert.strictEqual(
-        extension.isEUCJP(content),
-        false,
-        `content: ${content.toString("hex")}`,
-      );
+    const notEucjpDocument = await vscode.workspace.openTextDocument({
+      content: "い", // 文字列は何でも良い
+      encoding: "utf8",
     });
-
-    // VS Code 1.100.0以降でのみTextDocument.encodingで判定する
-    // 本拡張機能の最小サポートバージョンは1.100.0未満なので、
-    // 実行環境が1.100.0以降のバージョンのときのみテストする
-    const vscodeVersion = vscode.version.split('.').map(Number);
-    const isVscodeEncodingApiAvailable =
-      vscodeVersion[0] > 1 || (vscodeVersion[0] === 1 && vscodeVersion[1] >= 100);
-
-    if (isVscodeEncodingApiAvailable) {
-      const eucjpDocument = await vscode.workspace.openTextDocument({
-        content: "あ", // 文字列は何でも良い
-        encoding: "eucjp",
-      });
-      assert.strictEqual(
-        extension.isEUCJP(eucjpDocument),
-        true,
-        `document: ${eucjpDocument.getText()}`,
-      );
-
-      const notEucjpDocument = await vscode.workspace.openTextDocument({
-        content: "い", // 文字列は何でも良い
-        encoding: "utf8",
-      });
-      assert.strictEqual(
-        extension.isEUCJP(notEucjpDocument),
-        false,
-        `document: ${notEucjpDocument.getText()}`,
-      );
-    }
+    assert.strictEqual(
+      extension.isEUCJP(notEucjpDocument),
+      false,
+      `document: ${notEucjpDocument.getText()}`,
+    );
   });
 
   /**


### PR DESCRIPTION
VS Code v1.100.0以降にサポートされているので、それ以降でのみAPIを利用する
実際はAPIの有無で判断している

## Issue

<!--
  ごく簡潔な修正を除いて、Issue作成後にpull requestしてください
-->

- #13

## 対応内容

<!--
  背景と対応した内容について説明。
  たいていのことはissueに書いていると思うので、issueに書いていないことがあればここに書いてください。
-->

## テスト

<!--
  追加したテストについて説明。
  機能を追加したり、挙動を変更したりした場合はテストを追加、もしくは変更する必要があります。
-->

isEUCJPにテストを追加しました。

## 残作業

<!--
  このPRでは解決していない内容について説明。
-->
