### PR TITLE
perf: 変換処理をindexOf走査とBuffer.copyベースに書き換え高速化

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -116,7 +116,11 @@ export function replaceSpecificCharacters(document: vscode.TextDocument) {
   // 既にファイルを保存しているため、変換後の文字列と変換前の文字列が同じなら何もしない
   // これをしないと、Ctrl+Sを押しっぱなしにしたときに、上書きできなかったとエラーが出てくる
   // TODO 全角チルダを波ダッシュに変換した際も前述のエラーを出さないようにしたい
-  if (Buffer.compare(convertedString, content) === 0) {
+  // 変換対象がない場合は入力のBufferがそのまま返るため、比較せずに終了できる
+  if (
+    convertedString === content ||
+    Buffer.compare(convertedString, content) === 0
+  ) {
     return;
   }
 
@@ -162,42 +166,57 @@ export function isEUCJP(str: vscode.TextDocument): boolean {
 export function replaceSpecificCharactersInBuffer(str: Buffer): Buffer {
   const config = vscode.workspace.getConfiguration("waveDashUnify");
 
-  const replacements: Map<string, Buffer> = new Map();
+  const convertsFullwidthTilde = config.get(
+    "fullwidthTildeToWaveDash",
+  ) as boolean;
+  const convertsNumeroSign = config.get("numeroSignToNumeroSign") as boolean;
 
-  if (config.get("fullwidthTildeToWaveDash")) {
-    replacements.set("8fa2b7", Buffer.from([0xa1, 0xc1])); // 全角チルダ -> 波ダッシュ
+  if (!convertsFullwidthTilde && !convertsNumeroSign) {
+    return str;
   }
 
-  if (config.get("numeroSignToNumeroSign")) {
-    replacements.set("8fa2f1", Buffer.from([0xad, 0xe2])); // 全角NO -> 全角NO
-  }
+  // 変換対象はいずれも 0x8F 0xA2 で始まる3バイト列のため、
+  // ネイティブ実装で高速な indexOf で先頭バイトの候補位置だけを走査する
+  const SS3 = 0x8f; // EUC-JPのシングルシフト(SS3)バイト。変換対象の先頭バイト
 
-  const convertedString: number[] = [];
-  let i = 0;
+  let converted: Buffer | undefined;
+  let writePos = 0; // convertedへの書き込み済み位置
+  let copiedPos = 0; // strのコピー済み位置
+  let i = str.indexOf(SS3);
 
-  while (i < str.length) {
-    let replaced = false;
+  while (i !== -1 && i + 2 < str.length) {
+    let replacement: [number, number] | undefined;
 
-    for (const [key, value] of replacements) {
-      const keyLength = key.length / 2; // Each hex character represents half a byte
-      if (
-        str.length - i >= keyLength &&
-        str.toString("hex", i, i + keyLength) === key
-      ) {
-        convertedString.push(...value);
-        i += keyLength;
-        replaced = true;
-        break;
+    if (str[i + 1] === 0xa2) {
+      if (convertsFullwidthTilde && str[i + 2] === 0xb7) {
+        replacement = [0xa1, 0xc1]; // 全角チルダ -> 波ダッシュ
+      } else if (convertsNumeroSign && str[i + 2] === 0xf1) {
+        replacement = [0xad, 0xe2]; // 全角NO -> 全角NO
       }
     }
 
-    if (!replaced) {
-      convertedString.push(str[i]);
-      i++;
+    if (replacement) {
+      // 3バイトを2バイトに置き換えるため、変換後は元の長さを超えない
+      converted ??= Buffer.allocUnsafe(str.length);
+
+      writePos += str.copy(converted, writePos, copiedPos, i);
+      converted[writePos++] = replacement[0];
+      converted[writePos++] = replacement[1];
+      copiedPos = i + 3;
+      i = str.indexOf(SS3, copiedPos);
+    } else {
+      i = str.indexOf(SS3, i + 1);
     }
   }
 
-  return Buffer.from(convertedString);
+  // 変換対象が1つもなければ、入力のBufferをそのまま返す
+  if (!converted) {
+    return str;
+  }
+
+  writePos += str.copy(converted, writePos, copiedPos);
+
+  return converted.subarray(0, writePos);
 }
 
 /**


### PR DESCRIPTION
## Issue

- #13

## 対応内容

保存イベントごとに実行される `replaceSpecificCharactersInBuffer` を書き換えて高速化しました。#13 は変換処理に時間がかかることで、保存イベントが連続発火した際に拡張機能の書き戻しと VS Code の保存が競合して起きているため、変換〜書き戻しの時間を短縮して競合ウィンドウを縮小するアプローチです。

### ボトルネック

現行実装は以下の2点が支配的コストでした。

1. 1バイトごとに `str.toString("hex", i, i + 3)` を呼び、パターン数 × ファイル全バイト分のヒープ文字列を生成している(10MB のファイルで最大約2,000万回の文字列アロケーション)
2. 出力を `number[]` に1バイトずつ `push` して構築し、最後に `Buffer.from(array)` で再コピーしている

また、変換対象が1文字もないファイル(保存連打時の大半のケース)でも上記のフルコストを払っていました。

### 検討した案と測定結果

以下の3案を実装して比較しました。

- **案A(現行)**: `toString("hex")` によるバイト走査 + `number[]` で出力構築(比較基準)
- **案B**: 出力を `Buffer.allocUnsafe` で1回だけ確保し、非マッチ区間を `Buffer#copy` で一括コピー。走査は1バイトずつの JS ループ
- **案C(採用)**: 案Bのコピー戦略に加えて、変換対象(`8F A2 B7` / `8F A2 F1`)の共通先頭バイト `0x8F` をネイティブ実装の `Buffer#indexOf` で走査し、後続2バイトのみ直接比較。マッチが1つもなければ入力の `Buffer` をそのまま返す fast path つき

測定結果(ms/run、Node.js v22 / Linux x64、warmup 1回 + 案Aは3回・案B/Cは20回の平均):

| シナリオ | 案A(現行) | 案B | 案C(採用) | 案Cの倍率(対A / 対B) |
| --- | ---: | ---: | ---: | --- |
| 10MB・変換対象なし | 2,835.52 | 25.73 | **0.32** | 8,795x / 80x |
| 10MB・変換対象100個 | 2,448.14 | 25.94 | **1.22** | 2,005x / 21x |
| 10MB・変換対象1万個 | 2,418.74 | 25.85 | **3.10** | 779x / 8x |
| 1MB・変換対象10個 | 245.92 | 2.86 | **1.00** | 247x / 3x |

### 案Cを採用した理由

- 全シナリオで最速でした。案Bとの差は走査方法によるもので、案Bはファイル全バイトを JS ループで比較するのに対し、案Cは通常のファイルにほぼ出現しない `0x8F`(EUC-JP の SS3 バイト)を SIMD 最適化されたネイティブの `indexOf` で探すため、ファイルの大部分を C++ 側で読み飛ばせます
- 変換対象がないファイルでは入力 `Buffer` をそのまま返すため、呼び出し側が参照比較だけで書き戻し不要と判定でき、ファイルの mtime が変わらず #13 の競合要因そのものが発生しなくなります
- 3案の出力一致は、端で切れたシーケンス(`8F A2` で終わるなど)・`0x8F` の連続・空バッファを含む10ケースで確認済みです

<details>
<summary>ベンチマークスクリプト(再現用)</summary>

```js
"use strict";
// Issue #13 ベンチマーク: replaceSpecificCharactersInBuffer の3実装比較
// (a) current: toString("hex") + number[]
// (b) copy: JSループでバイト走査 + Buffer.copy
// (c) indexOf: Buffer#indexOf走査 + Buffer.copy + マッチゼロ時fast path

const TILDE = Buffer.from([0x8f, 0xa2, 0xb7]);
const NUMERO = Buffer.from([0x8f, 0xa2, 0xf1]);

// ---- (a) 現行実装 ----
function currentImpl(str) {
  const replacements = new Map([
    ["8fa2b7", Buffer.from([0xa1, 0xc1])],
    ["8fa2f1", Buffer.from([0xad, 0xe2])],
  ]);

  const convertedString = [];
  let i = 0;

  while (i < str.length) {
    let replaced = false;

    for (const [key, value] of replacements) {
      const keyLength = key.length / 2;
      if (
        str.length - i >= keyLength &&
        str.toString("hex", i, i + keyLength) === key
      ) {
        convertedString.push(...value);
        i += keyLength;
        replaced = true;
        break;
      }
    }

    if (!replaced) {
      convertedString.push(str[i]);
      i++;
    }
  }

  return Buffer.from(convertedString);
}

// ---- (b) Buffer.copyベース、JSループ走査 ----
function copyImpl(str) {
  const out = Buffer.allocUnsafe(str.length);
  let writePos = 0;
  let copiedPos = 0;
  let i = 0;

  while (i < str.length) {
    if (str[i] === 0x8f && i + 2 < str.length && str[i + 1] === 0xa2) {
      const third = str[i + 2];
      if (third === 0xb7 || third === 0xf1) {
        writePos += str.copy(out, writePos, copiedPos, i);
        if (third === 0xb7) {
          out[writePos++] = 0xa1;
          out[writePos++] = 0xc1;
        } else {
          out[writePos++] = 0xad;
          out[writePos++] = 0xe2;
        }
        i += 3;
        copiedPos = i;
        continue;
      }
    }
    i++;
  }

  writePos += str.copy(out, writePos, copiedPos);
  return out.subarray(0, writePos);
}

// ---- (c) indexOf走査 + Buffer.copy + fast path ----
function indexOfImpl(str) {
  const SS3 = 0x8f;

  let converted;
  let writePos = 0;
  let copiedPos = 0;
  let i = str.indexOf(SS3);

  while (i !== -1 && i + 2 < str.length) {
    let replacement;

    if (str[i + 1] === 0xa2) {
      if (str[i + 2] === 0xb7) {
        replacement = [0xa1, 0xc1];
      } else if (str[i + 2] === 0xf1) {
        replacement = [0xad, 0xe2];
      }
    }

    if (replacement) {
      converted ??= Buffer.allocUnsafe(str.length);
      writePos += str.copy(converted, writePos, copiedPos, i);
      converted[writePos++] = replacement[0];
      converted[writePos++] = replacement[1];
      copiedPos = i + 3;
      i = str.indexOf(SS3, copiedPos);
    } else {
      i = str.indexOf(SS3, i + 1);
    }
  }

  if (!converted) {
    return str;
  }

  writePos += str.copy(converted, writePos, copiedPos);
  return converted.subarray(0, writePos);
}

// ---- テストデータ生成 ----
// EUC-JP風データ: "あ"(0xa4 0xa2) の繰り返し + ASCII
function makeData(sizeBytes, tildeCount, numeroCount) {
  const chunks = [];
  const filler = Buffer.from([0xa4, 0xa2, 0xa4, 0xa2, 0x61, 0x62, 0x0a]); // ああab\n
  const total = tildeCount + numeroCount;
  const fillerBytes = sizeBytes - 3 * total;
  const perSegment = total > 0 ? Math.floor(fillerBytes / total) : fillerBytes;

  for (let k = 0; k < total; k++) {
    let seg = 0;
    while (seg + filler.length <= perSegment) {
      chunks.push(filler);
      seg += filler.length;
    }
    chunks.push(k < tildeCount ? TILDE : NUMERO);
  }
  let remaining = sizeBytes - chunks.reduce((a, b) => a + b.length, 0);
  while (remaining >= filler.length) {
    chunks.push(filler);
    remaining -= filler.length;
  }
  return Buffer.concat(chunks);
}

// ---- 正当性チェック ----
const cases = [
  Buffer.from([0x8f, 0xa2, 0xb7]),
  Buffer.from([0x8f, 0xa2, 0xb7, 0x8f, 0xa2, 0xb7]),
  Buffer.from([0x31, 0x8f, 0xa2, 0xb7, 0x8f, 0xa2, 0xf1, 0x32]),
  Buffer.from([0xa4, 0xa2]),
  Buffer.from([0x8f, 0xa2]), // 途中で切れたシーケンス
  Buffer.from([0x8f, 0xa2, 0x00]),
  Buffer.from([0x8f, 0x8f, 0xa2, 0xb7]), // 0x8fの重なり
  Buffer.from([]),
  makeData(100_000, 50, 50),
  makeData(100_000, 0, 0),
];
for (const c of cases) {
  const a = currentImpl(c).toString("hex");
  const b = copyImpl(c).toString("hex");
  const d = indexOfImpl(c).toString("hex");
  if (a !== b || a !== d) {
    console.error("MISMATCH for input:", c.toString("hex"));
    console.error("  current:", a, "\n  copy:", b, "\n  indexOf:", d);
    process.exit(1);
  }
}
console.log("correctness: all implementations agree on", cases.length, "cases\n");

// ---- ベンチマーク ----
function bench(name, fn, data, runs) {
  fn(data); // warmup
  const t0 = process.hrtime.bigint();
  for (let r = 0; r < runs; r++) fn(data);
  const t1 = process.hrtime.bigint();
  const ms = Number(t1 - t0) / 1e6 / runs;
  console.log(`  ${name.padEnd(12)} ${ms.toFixed(2).padStart(10)} ms/run`);
  return ms;
}

const MB = 1024 * 1024;
const scenarios = [
  { label: "10MB, 変換対象なし", data: makeData(10 * MB, 0, 0) },
  { label: "10MB, 変換対象 100個", data: makeData(10 * MB, 50, 50) },
  { label: "10MB, 変換対象 10000個", data: makeData(10 * MB, 5000, 5000) },
  { label: "1MB, 変換対象 10個", data: makeData(1 * MB, 5, 5) },
];

for (const s of scenarios) {
  console.log(`${s.label} (${s.data.length} bytes)`);
  const a = bench("(a) current", currentImpl, s.data, 3);
  const b = bench("(b) copy", copyImpl, s.data, 20);
  const c = bench("(c) indexOf", indexOfImpl, s.data, 20);
  console.log(
    `  speedup: (b) ${(a / b).toFixed(0)}x, (c) ${(a / c).toFixed(0)}x, (c)/(b) ${(b / c).toFixed(1)}x\n`,
  );
}
```

</details>

## テスト

- 変換のセマンティクス(入出力)は不変のため、既存のユニットテスト・統合テストを期待値の変更なしで回帰テストとして使用します
- 上記ベンチマークスクリプト内で、現行実装と新実装の出力一致を10ケース(端で切れた `8F A2` シーケンス、`0x8F` の連続、空バッファ、10万バイトのデータ等)で確認済みです
- ローカルの開発環境ではネットワークポリシーにより `update.code.visualstudio.com` へ到達できず VS Code 統合テスト(`npm test`)を実行できなかったため、CI(3 OS マトリクス)での実行結果を確認してください。`tsc` / `eslint` / `webpack` / `prettier` はローカルでパス済みです

## 残作業

- 変換対象が**ある**大きいファイルを保存連打した場合の競合は、書き戻し自体は依然発生するため理論上ゼロにはなりません(競合ウィンドウが数秒→数msに縮小するため実用上はほぼ再現しない見込み)。根本解決には保存フロー自体の変更(#13 で過去に検討された保存イベントの置き換え等)が必要で、本PRのスコープ外です

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018DRjXoVZGKPGroQqUzLN9y