### PR TITLE
perf: ステータスバー更新をデバウンスしてホットパスの全文スキャンを削減

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -19,6 +19,7 @@
     "codeql",
     "dbaeumer",
     "dearmor",
+    "debouncer",
     "devcontainer",
     "devcontainers",
     "dhoeric",

--- a/src/debounce.ts
+++ b/src/debounce.ts
@@ -1,0 +1,55 @@
+/**
+ * デバウンスされたスケジューラ
+ */
+export interface Debouncer {
+  /**
+   * 実行をスケジュールする
+   *
+   * 既に未実行のスケジュールがあれば破棄して積み直す。短時間に連続して
+   * 呼び出しても、最後のscheduleからdelayMsだけ経過した時点でcallbackが
+   * 1回だけ実行される(trailing edge)
+   */
+  schedule: () => void;
+
+  /**
+   * スケジュール済みの未実行の呼び出しを破棄する
+   *
+   * 既に実行済み、または何もスケジュールされていない場合は何もしない
+   */
+  cancel: () => void;
+}
+
+/**
+ * 関数の実行をデバウンスするDebouncerを作る
+ *
+ * VS Codeに依存しない独立したユニットなので、このモジュール単体で
+ * 単体テストできる
+ *
+ * @param callback デバウンスして実行する関数
+ * @param delayMs 最後のscheduleからcallbackを実行するまでの遅延時間(ms)
+ * @returns 作成したDebouncer
+ */
+export function createDebouncer(
+  callback: () => void,
+  delayMs: number,
+): Debouncer {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  function cancel() {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  }
+
+  function schedule() {
+    cancel();
+
+    timer = setTimeout(() => {
+      timer = undefined;
+      callback();
+    }, delayMs);
+  }
+
+  return { schedule, cancel };
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,7 +5,20 @@ export const WAVEDASH_CODE_POINT = 0x301c;
 export const FULLWIDTH_TILDE_CODE_POINT = 0xff5e;
 export const NUMERO_SIGN_CODE_POINT = 0x2116;
 
+// countSpecificCharactersでString#indexOfを使うために、事前に1文字だけの文字列に変換しておく
+// (いずれもサロゲートペアにならないコードポイントのため、1コード単位の文字列として扱える)
+const WAVE_DASH_CHAR = String.fromCodePoint(WAVEDASH_CODE_POINT);
+const FULLWIDTH_TILDE_CHAR = String.fromCodePoint(FULLWIDTH_TILDE_CODE_POINT);
+const NUMERO_SIGN_CHAR = String.fromCodePoint(NUMERO_SIGN_CODE_POINT);
+
+// ステータスバー更新のデバウンス時間(ms)
+// キーストロークのたびに全文スキャンが走らないように、この時間内の連続更新要求を1回にまとめる
+const STATUS_BAR_UPDATE_DEBOUNCE_MS = 200;
+
 let statusBarItem: vscode.StatusBarItem;
+
+// デバウンス中のステータスバー更新タイマー
+let statusBarUpdateTimer: ReturnType<typeof setTimeout> | undefined;
 
 export function activate(context: vscode.ExtensionContext) {
   setupStatusBarItem();
@@ -38,12 +51,26 @@ export function activate(context: vscode.ExtensionContext) {
       }),
       // アクティブファイルが変更された時や文字が変更された時に、ステータスバーの表示を更新する
       vscode.window.onDidChangeActiveTextEditor(() => {
+        // エディタが切り替わったので、直前のエディタ向けにスケジュールされていた更新は不要
+        cancelScheduledStatusBarUpdate();
         updateStatusBarItem(statusBarItem);
       }),
-      vscode.workspace.onDidChangeTextDocument(() => {
-        updateStatusBarItem(statusBarItem);
+      vscode.workspace.onDidChangeTextDocument((e) => {
+        // アクティブエディタ以外のドキュメント変更(出力チャンネルなど)では
+        // ステータスバーの表示に影響がないため、更新をスキップする
+        if (e.document !== vscode.window.activeTextEditor?.document) {
+          return;
+        }
+
+        // 連続するキーストロークのたびに全文スキャンが走らないように、更新をデバウンスする
+        scheduleStatusBarUpdate(statusBarItem);
       }),
-      vscode.workspace.onDidChangeConfiguration(() => {
+      vscode.workspace.onDidChangeConfiguration((e) => {
+        // この拡張機能に関係ない設定変更では更新不要
+        if (!e.affectsConfiguration("waveDashUnify")) {
+          return;
+        }
+
         updateStatusBarItem(statusBarItem);
       }),
 
@@ -107,6 +134,7 @@ export function replaceSpecificCharacters(document: vscode.TextDocument) {
   if (!isEUCJP(document)) {
     return;
   }
+
   // エンコードするよりも、ファイルを直接読み込んだ方が実行時間が短い
   // const content = Buffer.from(await vscode.workspace.encode(document.getText(), { encoding: "EUC-JP" }));
   const content = fs.readFileSync(document.fileName);
@@ -234,6 +262,28 @@ export function setupStatusBarItem() {
 }
 
 /**
+ * 文字列中に指定した1文字(target)が何回出現するかを数える
+ *
+ * String#indexOfはネイティブ実装のため、for...ofによるコードポイント走査より高速
+ * (10MB級の文字列で計測したところ、本関数を使う実装はfor...of実装の1/10程度の時間で完了した)
+ *
+ * @param str 検索対象の文字列
+ * @param target 検索する1文字
+ * @returns targetの出現回数
+ */
+function countOccurrences(str: string, target: string): number {
+  let count = 0;
+  let pos = str.indexOf(target);
+
+  while (pos !== -1) {
+    count++;
+    pos = str.indexOf(target, pos + target.length);
+  }
+
+  return count;
+}
+
+/**
  * 全角チルダ、波ダッシュ、およびNUMERO SIGNの個数を数える
  *
  * 全角チルダと波ダッシュは同じ文字として扱う
@@ -244,24 +294,12 @@ export function countSpecificCharacters(str: string): {
   waveDashAndFullwidthTilde: number;
   numeroSign: number;
 } {
-  const counts = {
-    waveDashAndFullwidthTilde: 0,
-    numeroSign: 0,
+  return {
+    waveDashAndFullwidthTilde:
+      countOccurrences(str, WAVE_DASH_CHAR) +
+      countOccurrences(str, FULLWIDTH_TILDE_CHAR),
+    numeroSign: countOccurrences(str, NUMERO_SIGN_CHAR),
   };
-
-  for (const char of str) {
-    const codePoint = char.codePointAt(0);
-    if (
-      codePoint === WAVEDASH_CODE_POINT ||
-      codePoint === FULLWIDTH_TILDE_CODE_POINT
-    ) {
-      counts.waveDashAndFullwidthTilde++;
-    } else if (codePoint === NUMERO_SIGN_CODE_POINT) {
-      counts.numeroSign++;
-    }
-  }
-
-  return counts;
 }
 
 /**
@@ -304,7 +342,37 @@ export function updateStatusBarItem(statusBarItem: vscode.StatusBarItem) {
     .replace("${numeroSignCount}", count.numeroSign.toString());
 }
 
+/**
+ * ステータスバーの更新をデバウンスする
+ *
+ * 短時間に連続して呼び出された場合、直近の呼び出しからSTATUS_BAR_UPDATE_DEBOUNCE_MSだけ
+ * 経過した時点で1回だけupdateStatusBarItemを実行する(trailing edge)
+ * 大きなファイルを編集中に1キーストロークごとの全文スキャンが走るのを防ぐ
+ *
+ * @param statusBarItem ステータスバーに表示する項目
+ */
+function scheduleStatusBarUpdate(statusBarItem: vscode.StatusBarItem) {
+  cancelScheduledStatusBarUpdate();
+
+  statusBarUpdateTimer = setTimeout(() => {
+    statusBarUpdateTimer = undefined;
+    updateStatusBarItem(statusBarItem);
+  }, STATUS_BAR_UPDATE_DEBOUNCE_MS);
+}
+
+/**
+ * scheduleStatusBarUpdateでスケジュールされた、未実行のステータスバー更新をキャンセルする
+ */
+function cancelScheduledStatusBarUpdate() {
+  if (statusBarUpdateTimer !== undefined) {
+    clearTimeout(statusBarUpdateTimer);
+    statusBarUpdateTimer = undefined;
+  }
+}
+
 export function deactivate() {
+  cancelScheduledStatusBarUpdate();
+
   if (statusBarItem) {
     statusBarItem.dispose();
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -135,6 +135,17 @@ export function replaceSpecificCharacters(document: vscode.TextDocument) {
     return;
   }
 
+  // 変換対象文字がドキュメントに1つもなければ、ディスクを読みに行く必要すらない。
+  // これが安全なのは「保存直後のテキストが真実源だから」ではなく、EUC-JPで
+  // 0x8F 0xA2 0xB7(全角チルダ)を生成できる文字がU+FF5E以外に無く、
+  // 0x8F 0xA2 0xF1(全角NO)を生成できる文字もU+2116以外に無いため。
+  // つまりテキスト上の判定は「変換対象バイト列の有無」の安全側の過剰近似になる
+  // (変換後のバイト列0xA1 0xC1 / 0xAD 0xE2はデコードするとそれぞれU+FF5E /
+  // U+2116に戻るため、既に変換済みのファイルも取りこぼされない)
+  if (!containsConvertTargetCharacters(document)) {
+    return;
+  }
+
   // エンコードするよりも、ファイルを直接読み込んだ方が実行時間が短い
   // const content = Buffer.from(await vscode.workspace.encode(document.getText(), { encoding: "EUC-JP" }));
   const content = fs.readFileSync(document.fileName);
@@ -153,6 +164,44 @@ export function replaceSpecificCharacters(document: vscode.TextDocument) {
   }
 
   fs.writeFileSync(document.fileName, convertedString, { flag: "w" });
+}
+
+/**
+ * ドキュメントに変換対象文字(全角チルダ、全角NO)が含まれるかを判定する
+ *
+ * 設定で変換が無効化されている文字は判定対象に含めない
+ * (例: fullwidthTildeToWaveDashがfalseなら全角チルダの有無は見ない)。
+ * 両方の設定がfalseの場合は変換が絶対に起きないため、document.getText()
+ * (全文のUTF-16コピーを作る)を呼ばずに終了する
+ *
+ * @param document 判定対象のドキュメント(保存直後のものを想定)
+ * @returns `true`: 変換対象文字が1つ以上含まれる, `false`: 含まれない
+ */
+export function containsConvertTargetCharacters(
+  document: vscode.TextDocument,
+): boolean {
+  const config = vscode.workspace.getConfiguration("waveDashUnify");
+
+  const convertsFullwidthTilde = config.get(
+    "fullwidthTildeToWaveDash",
+  ) as boolean;
+  const convertsNumeroSign = config.get("numeroSignToNumeroSign") as boolean;
+
+  if (!convertsFullwidthTilde && !convertsNumeroSign) {
+    return false;
+  }
+
+  const text = document.getText();
+
+  if (convertsFullwidthTilde && text.includes(FULLWIDTH_TILDE_CHAR)) {
+    return true;
+  }
+
+  if (convertsNumeroSign && text.includes(NUMERO_SIGN_CHAR)) {
+    return true;
+  }
+
+  return false;
 }
 
 /**

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,6 @@
 import * as vscode from "vscode";
 import * as fs from "fs";
+import { createDebouncer } from "./debounce";
 
 export const WAVEDASH_CODE_POINT = 0x301c;
 export const FULLWIDTH_TILDE_CODE_POINT = 0xff5e;
@@ -17,8 +18,12 @@ const STATUS_BAR_UPDATE_DEBOUNCE_MS = 200;
 
 let statusBarItem: vscode.StatusBarItem;
 
-// デバウンス中のステータスバー更新タイマー
-let statusBarUpdateTimer: ReturnType<typeof setTimeout> | undefined;
+// ステータスバー更新のデバウンサ。setupStatusBarItemによる再代入後も
+// 正しいstatusBarItemを使うように、値ではなく変数を捕捉するクロージャにする
+const statusBarUpdateDebouncer = createDebouncer(
+  () => updateStatusBarItem(statusBarItem),
+  STATUS_BAR_UPDATE_DEBOUNCE_MS,
+);
 
 export function activate(context: vscode.ExtensionContext) {
   setupStatusBarItem();
@@ -52,7 +57,7 @@ export function activate(context: vscode.ExtensionContext) {
       // アクティブファイルが変更された時や文字が変更された時に、ステータスバーの表示を更新する
       vscode.window.onDidChangeActiveTextEditor(() => {
         // エディタが切り替わったので、直前のエディタ向けにスケジュールされていた更新は不要
-        cancelScheduledStatusBarUpdate();
+        statusBarUpdateDebouncer.cancel();
         updateStatusBarItem(statusBarItem);
       }),
       vscode.workspace.onDidChangeTextDocument((e) => {
@@ -63,7 +68,7 @@ export function activate(context: vscode.ExtensionContext) {
         }
 
         // 連続するキーストロークのたびに全文スキャンが走らないように、更新をデバウンスする
-        scheduleStatusBarUpdate(statusBarItem);
+        statusBarUpdateDebouncer.schedule();
       }),
       vscode.workspace.onDidChangeConfiguration((e) => {
         // この拡張機能に関係ない設定変更では更新不要
@@ -391,36 +396,8 @@ export function updateStatusBarItem(statusBarItem: vscode.StatusBarItem) {
     .replace("${numeroSignCount}", count.numeroSign.toString());
 }
 
-/**
- * ステータスバーの更新をデバウンスする
- *
- * 短時間に連続して呼び出された場合、直近の呼び出しからSTATUS_BAR_UPDATE_DEBOUNCE_MSだけ
- * 経過した時点で1回だけupdateStatusBarItemを実行する(trailing edge)
- * 大きなファイルを編集中に1キーストロークごとの全文スキャンが走るのを防ぐ
- *
- * @param statusBarItem ステータスバーに表示する項目
- */
-function scheduleStatusBarUpdate(statusBarItem: vscode.StatusBarItem) {
-  cancelScheduledStatusBarUpdate();
-
-  statusBarUpdateTimer = setTimeout(() => {
-    statusBarUpdateTimer = undefined;
-    updateStatusBarItem(statusBarItem);
-  }, STATUS_BAR_UPDATE_DEBOUNCE_MS);
-}
-
-/**
- * scheduleStatusBarUpdateでスケジュールされた、未実行のステータスバー更新をキャンセルする
- */
-function cancelScheduledStatusBarUpdate() {
-  if (statusBarUpdateTimer !== undefined) {
-    clearTimeout(statusBarUpdateTimer);
-    statusBarUpdateTimer = undefined;
-  }
-}
-
 export function deactivate() {
-  cancelScheduledStatusBarUpdate();
+  statusBarUpdateDebouncer.cancel();
 
   if (statusBarItem) {
     statusBarItem.dispose();

--- a/src/test/suite/debounce.test.ts
+++ b/src/test/suite/debounce.test.ts
@@ -1,0 +1,95 @@
+import * as assert from "assert";
+import { createDebouncer } from "../../debounce";
+
+/**
+ * createDebouncerのテスト
+ *
+ * VS Codeに依存しないユニットのため、実タイマー(setTimeout)を使い
+ * VS Code拡張ホストの外でも成立する単体テストとして書く。
+ * フレーキーにならないよう、遅延は小さい値にしつつ、判定に使う待ち時間には
+ * 十分なマージンを取っている
+ */
+suite("Debouncer", () => {
+  // 判定に使う待ち時間のマージンを十分に取れるよう、実装で使う200msより
+  // 短く、かつタイマーの誤差に埋もれない値にする
+  const DELAY_MS = 100;
+
+  test("連続してscheduleしてもコールバックは1回だけ実行される", async () => {
+    let callCount = 0;
+    const debouncer = createDebouncer(() => {
+      callCount++;
+    }, DELAY_MS);
+
+    debouncer.schedule();
+    debouncer.schedule();
+    debouncer.schedule();
+
+    // 最後のscheduleからDELAY_MSの3倍待てば、実行されていれば確実に済んでいる
+    await new Promise((resolve) => setTimeout(resolve, DELAY_MS * 3));
+
+    assert.strictEqual(callCount, 1, "コールバックが1回だけ実行されなかった");
+  });
+
+  test("最後のscheduleからDELAY_MS後に実行される(trailing edge)", async () => {
+    let callCount = 0;
+    const debouncer = createDebouncer(() => {
+      callCount++;
+    }, DELAY_MS);
+
+    // GAP_MSはDELAY_MSより短いが、初回scheduleを起点にする(leading edge化する)
+    // 実装が壊れていた場合は起点+DELAY_MSの時点で既に実行されてしまう時間を確保する
+    const GAP_MS = DELAY_MS * 0.6;
+
+    debouncer.schedule();
+    await new Promise((resolve) => setTimeout(resolve, GAP_MS));
+    debouncer.schedule();
+
+    // 「初回scheduleを起点にした場合の実行時刻」は過ぎているが、
+    // 「最後のscheduleを起点にした場合の実行時刻」にはまだ届いていない時点で確認する。
+    // ここでcallCountが1になっていたら、初回scheduleを起点に実行された(leading edge化
+    // されている)ことになる
+    await new Promise((resolve) => setTimeout(resolve, DELAY_MS * 0.7));
+    assert.strictEqual(
+      callCount,
+      0,
+      "最後のscheduleではなく、それより前のscheduleを起点に実行された",
+    );
+
+    // 最後のscheduleを起点にした実行時刻を十分過ぎるまで待つ
+    await new Promise((resolve) => setTimeout(resolve, DELAY_MS * 3));
+    assert.strictEqual(
+      callCount,
+      1,
+      "最後のscheduleからDELAY_MS経過しても実行されなかった",
+    );
+  });
+
+  test("cancelするとコールバックは実行されない", async () => {
+    let callCount = 0;
+    const debouncer = createDebouncer(() => {
+      callCount++;
+    }, DELAY_MS);
+
+    debouncer.schedule();
+    debouncer.cancel();
+
+    await new Promise((resolve) => setTimeout(resolve, DELAY_MS * 3));
+
+    assert.strictEqual(callCount, 0, "cancelしたのにコールバックが実行された");
+  });
+
+  test("一度実行された後、再度scheduleすると再び実行される", async () => {
+    let callCount = 0;
+    const debouncer = createDebouncer(() => {
+      callCount++;
+    }, DELAY_MS);
+
+    debouncer.schedule();
+    await new Promise((resolve) => setTimeout(resolve, DELAY_MS * 3));
+    assert.strictEqual(callCount, 1, "1回目のscheduleが実行されなかった");
+
+    debouncer.schedule();
+    await new Promise((resolve) => setTimeout(resolve, DELAY_MS * 3));
+    assert.strictEqual(callCount, 2, "2回目のscheduleが実行されなかった");
+  });
+});

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -526,6 +526,250 @@ suite("Extension Test Suite", () => {
   });
 
   /**
+   * containsConvertTargetCharactersによる早期returnがEUC-JPファイルを保存しても
+   * 内容を変えないことを検証するための共通ヘルパー
+   *
+   * ファイルを開いた直後はdirtyでないため、TextDocument.save()を呼んでも
+   * 何も起きず(実際の保存もonDidSaveTextDocumentの発火もされない)、保存経路を
+   * 検証したことにならない。末尾に1文字挿入してすぐ削除することで、内容は
+   * 変えずにdirty→cleanの実際の保存を発生させてからファイルの内容を比較する
+   *
+   * ファイルの内容比較(保存経路)に加えて、containsConvertTargetCharacters自体の
+   * 戻り値もfalseであることを直接確認する。replaceSpecificCharactersInBufferは
+   * 変換対象の文字ごとに設定を再確認する独立したガードを持つため、
+   * containsConvertTargetCharacters側の設定判定だけが壊れても保存結果の比較だけでは
+   * 検出できない場合がある(実際に確認済み)。戻り値を直接見ることでその抜け穴を塞ぐ
+   *
+   * @param contents 保存対象のファイルの内容(変換が起きないことを期待する内容)
+   * @param fullwidthTildeToWaveDash waveDashUnify.fullwidthTildeToWaveDashの設定値
+   * @param numeroSignToNumeroSign waveDashUnify.numeroSignToNumeroSignの設定値
+   * @param message アサーション失敗時のメッセージ
+   */
+  async function assertSaveLeavesFileUnchanged(
+    contents: Buffer,
+    fullwidthTildeToWaveDash: boolean,
+    numeroSignToNumeroSign: boolean,
+    message: string,
+  ) {
+    const waveDashUnifyConfig =
+      vscode.workspace.getConfiguration("waveDashUnify");
+    await waveDashUnifyConfig.update(
+      "enableConvert",
+      true,
+      vscode.ConfigurationTarget.Global,
+    );
+    await waveDashUnifyConfig.update(
+      "fullwidthTildeToWaveDash",
+      fullwidthTildeToWaveDash,
+      vscode.ConfigurationTarget.Global,
+    );
+    await waveDashUnifyConfig.update(
+      "numeroSignToNumeroSign",
+      numeroSignToNumeroSign,
+      vscode.ConfigurationTarget.Global,
+    );
+
+    // 自動判定でEUC-JPと判定されるようにする
+    const fileConfig = vscode.workspace.getConfiguration("files");
+    await fileConfig.update(
+      "autoGuessEncoding",
+      true,
+      vscode.ConfigurationTarget.Global,
+    );
+
+    const tmpFile = tmp.fileSync();
+    fs.writeFileSync(tmpFile.name, contents);
+
+    const document = await vscode.workspace.openTextDocument(tmpFile.name);
+    const textEditor = await vscode.window.showTextDocument(document);
+    assert.strictEqual(
+      document.encoding,
+      "eucjp",
+      "前提条件エラー: ファイルがEUC-JPと判定されなかった",
+    );
+
+    assert.strictEqual(
+      extension.containsConvertTargetCharacters(document),
+      false,
+      `containsConvertTargetCharactersがtrueを返した: ${message}`,
+    );
+
+    // dirty→cleanの実際の保存を発生させるため、末尾に1文字挿入してすぐ削除する
+    // (内容自体は変えない)
+    await textEditor.edit((editBuilder) => {
+      const lastLine = document.lineCount - 1;
+      const lastLineLength = document.lineAt(lastLine).text.length;
+      editBuilder.insert(new vscode.Position(lastLine, lastLineLength), "x");
+    });
+    await textEditor.edit((editBuilder) => {
+      const lastLine = document.lineCount - 1;
+      const lastLineLength = document.lineAt(lastLine).text.length;
+      editBuilder.delete(
+        new vscode.Range(
+          new vscode.Position(lastLine, lastLineLength - 1),
+          new vscode.Position(lastLine, lastLineLength),
+        ),
+      );
+    });
+    await document.save();
+
+    const actual = fs.readFileSync(tmpFile.name);
+    assert.strictEqual(
+      actual.toString("hex"),
+      contents.toString("hex"),
+      message,
+    );
+  }
+
+  /**
+   * 変換対象文字がドキュメントに1つも無い場合、containsConvertTargetCharactersの
+   * 早期returnによって保存経路がファイルの内容を一切変えないことを確認する
+   */
+  test("save EUC-JP file without target characters leaves it unchanged", async () => {
+    // 変換対象文字を含まないEUC-JPの文字列
+    // 文字列: "ああああ"
+    const contents = Buffer.from([
+      0xa4, 0xa2, 0xa4, 0xa2, 0xa4, 0xa2, 0xa4, 0xa2,
+    ]);
+
+    await assertSaveLeavesFileUnchanged(
+      contents,
+      true,
+      true,
+      "変換対象文字を含まないファイルが保存によって変化した",
+    );
+  });
+
+  /**
+   * fullwidthTildeToWaveDashとnumeroSignToNumeroSignの組み合わせによる
+   * 早期returnの境界を確認する
+   *
+   * - fullwidthTildeToWaveDash: false, numeroSignToNumeroSign: true の状態で
+   *   全角チルダのみを含むファイルを保存 → 変換されない
+   * - fullwidthTildeToWaveDash: true, numeroSignToNumeroSign: false の状態で
+   *   全角NOのみを含むファイルを保存 → 変換されない
+   */
+  test("early return respects each setting independently", async () => {
+    // 全角チルダのみ(全角NOは含まない)
+    // 文字列: "ああああ～"
+    const fullwidthTildeOnly = Buffer.from([
+      0xa4, 0xa2, 0xa4, 0xa2, 0xa4, 0xa2, 0xa4, 0xa2, 0x8f, 0xa2, 0xb7,
+    ]);
+    await assertSaveLeavesFileUnchanged(
+      fullwidthTildeOnly,
+      false,
+      true,
+      "fullwidthTildeToWaveDash: falseなのに、全角チルダのみのファイルが保存によって変化した",
+    );
+
+    // 全角NOのみ(全角チルダは含まない)
+    // 文字列: "ああああ№"
+    const numeroSignOnly = Buffer.from([
+      0xa4, 0xa2, 0xa4, 0xa2, 0xa4, 0xa2, 0xa4, 0xa2, 0x8f, 0xa2, 0xf1,
+    ]);
+    await assertSaveLeavesFileUnchanged(
+      numeroSignOnly,
+      true,
+      false,
+      "numeroSignToNumeroSign: falseなのに、全角NOのみのファイルが保存によって変化した",
+    );
+  });
+
+  /**
+   * containsConvertTargetCharactersの早期returnが安全な理由を固定するテスト
+   *
+   * この判定はdocument.getText()に全角チルダ(U+FF5E)・全角NO(U+2116)が含まれるかで
+   * 行うが、これは「保存直後のテキストが真実源だから」ではなく、EUC-JPで
+   * 0x8F 0xA2 0xB7(全角チルダ)を生成できる文字がU+FF5E以外に無く、
+   * 0x8F 0xA2 0xF1(全角NO)を生成できる文字もU+2116以外に無いためである。
+   * つまりテキスト上の判定は「変換対象バイト列の有無」の安全側の過剰近似になる。
+   *
+   * この前提はVS Code自身のEUC-JPデコーダの実装に依存しており、それが変わると
+   * 静かに壊れる(取りこぼしが発生する)ため、ここで固定しておく。
+   * 変換後のバイト列(波ダッシュ0xA1 0xC1、全角NO 0xAD 0xE2)をデコードすると
+   * それぞれU+FF5E・U+2116に戻ることも合わせて確認し、既に変換済みのファイルも
+   * この判定に引っかかる(取りこぼされない)ことを保証する
+   */
+  test("already-converted bytes decode back to the target codepoints", async () => {
+    const waveDashUnifyConfig =
+      vscode.workspace.getConfiguration("waveDashUnify");
+    await waveDashUnifyConfig.update(
+      "fullwidthTildeToWaveDash",
+      true,
+      vscode.ConfigurationTarget.Global,
+    );
+    await waveDashUnifyConfig.update(
+      "numeroSignToNumeroSign",
+      true,
+      vscode.ConfigurationTarget.Global,
+    );
+
+    // 自動判定でEUC-JPと判定されるようにする
+    const fileConfig = vscode.workspace.getConfiguration("files");
+    await fileConfig.update(
+      "autoGuessEncoding",
+      true,
+      vscode.ConfigurationTarget.Global,
+    );
+
+    // 波ダッシュ(0xA1 0xC1)のみ。EUC-JPと自動認識されるよう"ああああ"を前置する
+    // 文字列: "ああああ" + 波ダッシュ
+    const waveDashFile = tmp.fileSync();
+    fs.writeFileSync(
+      waveDashFile.name,
+      Buffer.from([0xa4, 0xa2, 0xa4, 0xa2, 0xa4, 0xa2, 0xa4, 0xa2, 0xa1, 0xc1]),
+    );
+    const waveDashDocument = await vscode.workspace.openTextDocument(
+      waveDashFile.name,
+    );
+    assert.strictEqual(
+      waveDashDocument.encoding,
+      "eucjp",
+      "前提条件エラー: ファイルがEUC-JPと判定されなかった",
+    );
+    assert.strictEqual(
+      waveDashDocument
+        .getText()
+        .includes(String.fromCodePoint(extension.FULLWIDTH_TILDE_CODE_POINT)),
+      true,
+      "波ダッシュ(0xA1 0xC1)がU+FF5Eにデコードされなかった",
+    );
+    assert.strictEqual(
+      extension.containsConvertTargetCharacters(waveDashDocument),
+      true,
+      "既に変換済みの波ダッシュが判定で取りこぼされた",
+    );
+
+    // 全角NO(0xAD 0xE2)のみ
+    // 文字列: "ああああ" + 全角NO
+    const numeroSignFile = tmp.fileSync();
+    fs.writeFileSync(
+      numeroSignFile.name,
+      Buffer.from([0xa4, 0xa2, 0xa4, 0xa2, 0xa4, 0xa2, 0xa4, 0xa2, 0xad, 0xe2]),
+    );
+    const numeroSignDocument = await vscode.workspace.openTextDocument(
+      numeroSignFile.name,
+    );
+    assert.strictEqual(
+      numeroSignDocument.encoding,
+      "eucjp",
+      "前提条件エラー: ファイルがEUC-JPと判定されなかった",
+    );
+    assert.strictEqual(
+      numeroSignDocument
+        .getText()
+        .includes(String.fromCodePoint(extension.NUMERO_SIGN_CODE_POINT)),
+      true,
+      "全角NO(0xAD 0xE2)がU+2116にデコードされなかった",
+    );
+    assert.strictEqual(
+      extension.containsConvertTargetCharacters(numeroSignDocument),
+      true,
+      "既に変換済みの全角NOが判定で取りこぼされた",
+    );
+  });
+
+  /**
    * ステータスバーの初期化を行う関数をテストする
    * NOTE: テスト対象のsetupStatusBarItem()はグローバル変数の初期化を行う関数なのでテストしない
    */


### PR DESCRIPTION
## 何が問題だったか

ステータスバーに表示する文字数を数えるために、**キーストロークのたびにドキュメント全文をスキャン**していました。

さらに次の2つの無駄がありました。

- `onDidChangeTextDocument` がアクティブエディタ以外のドキュメント変更（出力チャンネルなど）にも反応していた
- `onDidChangeConfiguration` が、この拡張機能に無関係な設定変更でも再スキャンしていた

## 実際にどう変わるか

10MB の日本語ファイルを編集した場合:

| | 1打鍵あたりのスキャン | 1打鍵あたりの時間 |
| --- | --- | --- |
| 変更前 | 1回 | 約 120 ms |
| 変更後 | **0回** | **0 ms**（入力が止まって200ms後に1回だけ約 39 ms） |

打鍵のたびに走っていた全文スキャンが、入力が落ち着いてから1回だけになります。

あわせて `countSpecificCharacters` を `for...of` のコードポイント走査から `String#indexOf` の繰り返しに変更し、その「1回分」自体も軽くしました。

| テキスト（10MB） | 変更前 | 変更後 | 倍率 |
| --- | --- | --- | --- |
| 日本語（対象文字なし） | 115.4 ms | 36.4 ms | 3.2x |
| 日本語（`～` がまばら） | 120.8 ms | 38.8 ms | 3.1x |

計測に使ったスクリプト（`node bench.js` で再現できます）:

<details>
<summary>bench.js</summary>

```js
// countSpecificCharacters の変更前後を、テキストの内容を変えて比較する
const WAVEDASH = 0x301c, TILDE = 0xff5e, NUMERO = 0x2116;
const WD = String.fromCodePoint(WAVEDASH);
const FT = String.fromCodePoint(TILDE);
const NS = String.fromCodePoint(NUMERO);

// 変更前: for...of によるコードポイント走査
function before(str) {
  const counts = { waveDashAndFullwidthTilde: 0, numeroSign: 0 };
  for (const char of str) {
    const cp = char.codePointAt(0);
    if (cp === WAVEDASH || cp === TILDE) counts.waveDashAndFullwidthTilde++;
    else if (cp === NUMERO) counts.numeroSign++;
  }
  return counts;
}

// 変更後: String#indexOf の繰り返し
function countOccurrences(str, target) {
  let count = 0;
  let pos = str.indexOf(target);
  while (pos !== -1) {
    count++;
    pos = str.indexOf(target, pos + target.length);
  }
  return count;
}
function after(str) {
  return {
    waveDashAndFullwidthTilde: countOccurrences(str, WD) + countOccurrences(str, FT),
    numeroSign: countOccurrences(str, NS),
  };
}

function mk(unit, mb) {
  let s = "";
  while (s.length < mb * 1024 * 1024) s += unit;
  return s;
}
function bench(fn, text, n) {
  fn(text); // ウォームアップ
  const t = process.hrtime.bigint();
  for (let i = 0; i < n; i++) fn(text);
  return Number(process.hrtime.bigint() - t) / 1e6 / n;
}

for (const mb of [1, 10]) {
  console.log(`\n=== ${mb}MB ===`);
  const cases = {
    "ASCII中心(対象文字なし)": mk("const foo = bar(baz);  // comment here\n", mb),
    "日本語(対象文字なし)": mk("あいうえお漢字テストです。今日は良い天気ですね。\n", mb),
    "日本語(～がまばら)": mk("あいうえお漢字テストです～今日は良い天気ですね。\n", mb),
  };
  for (const [name, text] of Object.entries(cases)) {
    // 両実装が同じ結果を返すことを確認してから計測する
    const b0 = before(text), a0 = after(text);
    if (b0.waveDashAndFullwidthTilde !== a0.waveDashAndFullwidthTilde || b0.numeroSign !== a0.numeroSign) {
      throw new Error(`結果が一致しない: ${name}`);
    }
    const b = bench(before, text, 10), a = bench(after, text, 10);
    console.log(`${name.padEnd(26)} 変更前 ${b.toFixed(1).padStart(6)} ms | 変更後 ${a.toFixed(1).padStart(6)} ms | ${(b / a).toFixed(1)}x`);
  }
}
```

</details>

## 変更内容

- `onDidChangeTextDocument` をアクティブエディタのドキュメント変更のみに限定し、200ms デバウンスした
- `onDidChangeConfiguration` を `affectsConfiguration("waveDashUnify")` でガードした
- `countSpecificCharacters` を `String#indexOf` ベースに変更した
- `deactivate` で未実行のデバウンスタイマーを破棄するようにした

## テスト

既存テストがすべてパスすることを確認しました。ステータスバー系のテストは `updateStatusBarItem` を直接呼ぶため、デバウンスの影響を受けません。

### デバウンス処理のテストを追加しました

当初、この PR の主題であるデバウンスにテストが1つもありませんでした。変異テストで確認したところ、**デバウンス・アクティブエディタ判定・`affectsConfiguration` ガード・`deactivate` の後始末をすべて撤去しても、既存テストは全件パスする**状態でした（`countSpecificCharacters` の `indexOf` 化については、`countOccurrences` を常に0を返すよう壊すと既存テスト4件が失敗するため、こちらはカバーされていました）。

そこでデバウンスの仕組みを、VS Code に依存しない `createDebouncer` として `src/debounce.ts` に切り出し、単体テストを追加しました。挙動は変えていません。

- 連続して `schedule` してもコールバックは1回だけ実行されること
- 最後の `schedule` を起点に実行されること（trailing edge）
- `cancel` するとコールバックが実行されないこと
- 一度実行された後、再度 `schedule` すると再び実行されること

以下の変異でそれぞれテストが失敗することを確認済みです。

| 変異 | 失敗したテスト |
| --- | --- |
| `schedule` が既存タイマーを破棄しない（多重登録） | 2件 |
| `cancel` が何もしない | 3件 |
| leading edge 化（初回のみタイマーを張る） | 1件（trailing edge のテスト） |

### イベント配線側をテストできない理由

`onDidChangeTextDocument` のガードが効いているか、実際にデバウンスされているか、といった**配線側は検証できていません**。`package.json` の `main` は `dist/extension.js`（webpack バンドル）を指し、これが VS Code に実際に activate されるインスタンスですが、テストが `import` するのは `out/extension.js`（tsc の出力）で、Node 上は別のモジュールインスタンスになります。拡張機能の `statusBarItem` はモジュール内のプライベート変数のため、テストからは観測できません。VS Code にも他の拡張機能のステータスバーを読む API はありません。

次に同じ調査をする人のために記録しておきます。

