### PR TITLE
chore: .claudeディレクトリをVSIXパッケージから除外する

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -16,3 +16,4 @@ webpack.config.js
 .cspell.json
 doc/overwrite-error.png
 .nvmrc
+.claude/**


### PR DESCRIPTION
## 何が問題だったか

`vsce package` で作った VSIX に `.claude/settings.local.json` が同梱されていました。

`.claude` 配下はユーザーのグローバル gitignore で無視されているため `git status` には現れませんが、`.vscodeignore` は gitignore とは無関係にファイルシステムを見るため、パッケージには入ってしまいます。

このリポジトリで Claude Code を使う環境には `.claude/settings.local.json` が恒常的に存在するため、ローカルで `vsce package` して配布・共有した場合にローカル設定が同梱されます。

## 確認方法

修正前:

```console
$ npx vsce package --out /tmp/before.vsix
$ python3 -c "
import zipfile,sys
z=zipfile.ZipFile(sys.argv[1])
for n in sorted(z.namelist()): print(f'{z.getinfo(n).file_size:>8}  {n}')
" /tmp/before.vsix | grep -i claude
    1429  extension/.claude/settings.local.json
```

`.vscodeignore` に `.claude/**` を追加後:

```console
$ npx vsce package --out /tmp/after.vsix
$ python3 -c "
import zipfile,sys
z=zipfile.ZipFile(sys.argv[1])
for n in sorted(z.namelist()): print(f'{z.getinfo(n).file_size:>8}  {n}')
" /tmp/after.vsix | grep -i claude
$ echo $?
1
```

`.claude` 関連のファイルが一切含まれなくなり、他のファイルには変化がありません。
