### PR TITLE
docs: 波ダッシュのカウントを意図的に残している理由を明文化する

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -8,6 +8,15 @@ export const NUMERO_SIGN_CODE_POINT = 0x2116;
 
 // countSpecificCharactersでString#indexOfを使うために、事前に1文字だけの文字列に変換しておく
 // (いずれもサロゲートペアにならないコードポイントのため、1コード単位の文字列として扱える)
+//
+// WAVE_DASH_CHAR(U+301C)は、EUC-JPのファイルを扱う限りテキスト中に出現しない。
+// VS CodeのEUC-JPコーデックは 0xA1 0xC1(波ダッシュのバイト列)も
+// 0x8F 0xA2 0xB7(全角チルダのバイト列)も等しくU+FF5Eにデコードし、
+// 逆にU+301Cをエンコードすると表現できず'?'(0x3F)になる。
+// そのためWAVE_DASH_CHARを使ったカウントは実質デッドコードだが、
+// 将来UTF-8など他のエンコーディングを扱うようになればU+301Cが実際に
+// 現れうるため、意図的に残している(issue #635)。
+// この前提はsrc/test/suite/eucjp-encoding-invariants.test.tsで固定してある
 const WAVE_DASH_CHAR = String.fromCodePoint(WAVEDASH_CODE_POINT);
 const FULLWIDTH_TILDE_CHAR = String.fromCodePoint(FULLWIDTH_TILDE_CODE_POINT);
 const NUMERO_SIGN_CHAR = String.fromCodePoint(NUMERO_SIGN_CODE_POINT);
@@ -662,6 +671,11 @@ function countOccurrences(str: string, target: string): number {
  * 全角チルダ、波ダッシュ、およびNUMERO SIGNの個数を数える
  *
  * 全角チルダと波ダッシュは同じ文字として扱う
+ *
+ * EUC-JPのファイルではWAVE_DASH_CHAR(U+301C)の項が常に0件になり、
+ * 変換の前後でこのカウントは変化しない。理由と、それでも項を残している
+ * 判断についてはWAVE_DASH_CHARの定義箇所のコメントを参照
+ *
  * @param str 文字列
  * @returns 各文字の個数を含む辞書
  */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,10 +13,14 @@ export const NUMERO_SIGN_CODE_POINT = 0x2116;
 // VS CodeのEUC-JPコーデックは 0xA1 0xC1(波ダッシュのバイト列)も
 // 0x8F 0xA2 0xB7(全角チルダのバイト列)も等しくU+FF5Eにデコードし、
 // 逆にU+301Cをエンコードすると表現できず'?'(0x3F)になる。
-// そのためWAVE_DASH_CHARを使ったカウントは実質デッドコードだが、
-// 将来UTF-8など他のエンコーディングを扱うようになればU+301Cが実際に
-// 現れうるため、意図的に残している(issue #635)。
-// この前提はsrc/test/suite/eucjp-encoding-invariants.test.tsで固定してある
+// そのため変換対象であるEUC-JPのファイルに限れば、WAVE_DASH_CHARを使った
+// カウントは常に0件になる(issue #635)。
+// ただしステータスバーのカウント(updateStatusBarItem)はドキュメントの
+// エンコーディングを問わず動くため、UTF-8のファイルを開いている場合は
+// U+301Cが現時点で実際にカウントされる。この項を削除するとその表示が
+// 変わってしまうため残している。
+// EUC-JP側の前提はsrc/test/suite/eucjp-encoding-invariants.test.tsで
+// 固定してある
 const WAVE_DASH_CHAR = String.fromCodePoint(WAVEDASH_CODE_POINT);
 const FULLWIDTH_TILDE_CHAR = String.fromCodePoint(FULLWIDTH_TILDE_CODE_POINT);
 const NUMERO_SIGN_CHAR = String.fromCodePoint(NUMERO_SIGN_CODE_POINT);

--- a/src/test/suite/eucjp-encoding-invariants.test.ts
+++ b/src/test/suite/eucjp-encoding-invariants.test.ts
@@ -1,0 +1,125 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import * as extension from "../../extension";
+
+/**
+ * EUC-JPのコーデックに関する前提を固定化するテスト
+ *
+ * この拡張機能は「EUC-JPファイルをデコードした結果に波ダッシュ(U+301C)は
+ * 現れない」という前提の上に成り立っている(issue #635)。
+ * この前提はVS Code側のデコーダの挙動に依存するため、将来VS Codeの
+ * コーデック実装が変わった場合に気付けるよう、ここでテストとして固定する。
+ *
+ * 各テストは`vscode.workspace.decode`/`encode`に`encoding: "eucjp"`を
+ * 明示して使う。未対応のエンコーディング名を渡すと既定のエンコーディング
+ * (UTF-8)にフォールバックしてしまうため、UTF-8では成立しない
+ * バイト列との厳密比較で「本当にEUC-JPとして処理されたか」も併せて検証する
+ */
+suite("EUC-JP encoding invariants", () => {
+  // EUC-JPにおける波ダッシュのバイト列
+  const WAVE_DASH_BYTES = Uint8Array.from([0xa1, 0xc1]);
+  // EUC-JPにおける全角チルダのバイト列(3バイトのSS3領域)
+  const FULLWIDTH_TILDE_BYTES = Uint8Array.from([0x8f, 0xa2, 0xb7]);
+
+  const WAVE_DASH = String.fromCodePoint(extension.WAVEDASH_CODE_POINT);
+  const FULLWIDTH_TILDE = String.fromCodePoint(
+    extension.FULLWIDTH_TILDE_CODE_POINT,
+  );
+
+  const decodeEucjp = (bytes: Uint8Array): Thenable<string> =>
+    vscode.workspace.decode(bytes, { encoding: "eucjp" });
+  const encodeEucjp = (text: string): Thenable<Uint8Array> =>
+    vscode.workspace.encode(text, { encoding: "eucjp" });
+
+  test("波ダッシュのバイト列(0xA1 0xC1)は全角チルダ(U+FF5E)にデコードされる", async () => {
+    const decoded = await decodeEucjp(WAVE_DASH_BYTES);
+
+    assert.strictEqual(
+      decoded,
+      FULLWIDTH_TILDE,
+      "0xA1 0xC1がU+FF5Eにデコードされなかった",
+    );
+    assert.notStrictEqual(
+      decoded,
+      WAVE_DASH,
+      "0xA1 0xC1がU+301Cにデコードされた(EUC-JPのデコード結果に波ダッシュは現れないという前提が崩れている)",
+    );
+  });
+
+  test("全角チルダのバイト列(0x8F 0xA2 0xB7)も全角チルダ(U+FF5E)にデコードされる", async () => {
+    const decoded = await decodeEucjp(FULLWIDTH_TILDE_BYTES);
+
+    assert.strictEqual(
+      decoded,
+      FULLWIDTH_TILDE,
+      "0x8F 0xA2 0xB7がU+FF5Eにデコードされなかった",
+    );
+  });
+
+  test("全角チルダ(U+FF5E)は3バイトの全角チルダ(0x8F 0xA2 0xB7)にエンコードされる", async () => {
+    // VS CodeのEUC-JPコーデックは非対称で、0xA1 0xC1と0x8F 0xA2 0xB7の
+    // どちらもU+FF5Eにデコードされる一方、U+FF5Eをエンコードすると
+    // 常に3バイトの0x8F 0xA2 0xB7になる。
+    // つまりデコードとエンコードを往復しても0xA1 0xC1は得られないため、
+    // 文字列の再エンコードでは全角チルダ→波ダッシュの変換を実現できない。
+    //
+    // "eucjp"が実際に使われていることを確かめる対照実験でもある。
+    // UTF-8にフォールバックしていれば0xEF 0xBD 0x9Eになり、このテストが落ちる
+    const encoded = await encodeEucjp(FULLWIDTH_TILDE);
+
+    assert.deepStrictEqual(
+      Array.from(encoded),
+      Array.from(FULLWIDTH_TILDE_BYTES),
+      "U+FF5EがEUC-JPの0x8F 0xA2 0xB7にエンコードされなかった",
+    );
+  });
+
+  test("波ダッシュ(U+301C)はEUC-JPで表現できず'?'(0x3F)にエンコードされる", async () => {
+    const encoded = await encodeEucjp(WAVE_DASH);
+
+    assert.deepStrictEqual(
+      Array.from(encoded),
+      [0x3f],
+      "U+301Cが'?'(0x3F)にエンコードされなかった",
+    );
+    assert.notDeepStrictEqual(
+      Array.from(encoded),
+      Array.from(WAVE_DASH_BYTES),
+      "U+301Cが0xA1 0xC1にエンコードされた(U+301CはEUC-JPで表現できないという前提が崩れている)",
+    );
+  });
+
+  test("EUC-JPファイル由来のテキストではcountSpecificCharactersの波ダッシュ分は常に0件になる", async () => {
+    // 波ダッシュのバイト列と全角チルダのバイト列を混在させた
+    // EUC-JPファイル相当のバイト列を用意する
+    const bytes = Uint8Array.from([
+      ...WAVE_DASH_BYTES,
+      ...FULLWIDTH_TILDE_BYTES,
+      ...WAVE_DASH_BYTES,
+    ]);
+
+    const decoded = await decodeEucjp(bytes);
+
+    assert.strictEqual(
+      decoded.includes(WAVE_DASH),
+      false,
+      `デコード結果にU+301Cが含まれている: ${JSON.stringify(decoded)}`,
+    );
+
+    const count = extension.countSpecificCharacters(decoded);
+
+    // 3文字すべてがU+FF5Eとしてカウントされる。
+    // つまりcountSpecificCharactersのWAVE_DASH_CHAR分の寄与は0件であり、
+    // EUC-JPのファイルに対しては実質デッドコードになっている
+    assert.strictEqual(
+      count.waveDashAndFullwidthTilde,
+      3,
+      "全角チルダとしてのカウントが期待値と一致しなかった",
+    );
+    assert.strictEqual(
+      (decoded.match(new RegExp(FULLWIDTH_TILDE, "g")) ?? []).length,
+      count.waveDashAndFullwidthTilde,
+      "カウント結果が全角チルダの出現回数と一致しなかった(波ダッシュ分が加算されている)",
+    );
+  });
+});


### PR DESCRIPTION
Closes #635

## 対応方針

「現状維持 + コメントとテストで明文化」を選択した。コードの動作は一切変更していない(`src/extension.ts` の変更はコメントの追加のみ、14行の挿入で削除なし)。

## issueの確認事項への回答

### 1. 設定名やステータスバーの表示は実態と食い違っていないか → 変更しない

`waveDashAndFullwidthTildeCount` などの設定名と `statusBarFormat` のデフォルト値は変更しない。実態としてカウントされているのが全角チルダ由来の分だけであることは事実だが、既に `statusBarFormat` をカスタマイズしているユーザーにとって改名は破壊的変更になるため、名前の正確さよりも互換性を優先した。

### 2. `WAVE_DASH_CHAR` / `WAVEDASH_CODE_POINT` のカウント処理は残す必要があるか → 意図的に残す

EUC-JPの変換対象ファイルに限れば、この項は常に0件で実質デッドコードになる。

ただし`updateStatusBarItem`はアクティブなドキュメントのエンコーディングを一切確認せず`countSpecificCharacters`を呼んでいるため、**UTF-8のファイルを開いている場合はこの項は現時点で実際に機能している**(UTF-8のテキストにはU+301Cがそのまま出現しうる)。当初「将来UTF-8等に対応すれば意味を持つ」という将来形で説明していたが、これはレビューで指摘の通り不正確だった。ステータスバーのカウント機能自体はEUC-JP限定ではなく、拡張機能がアクティブ化されている間は常にどのファイルに対しても動作するため、削除するとUTF-8ファイルでの表示が現に壊れる。コード側のコメントは修正済み([e0b45a1](https://github.com/yutotnh/wave-dash-unify/commit/e0b45a1e6c968efb2b2e5094e9b8d92a6c573e9d))。

## 変更内容

### コメントの追加 (`src/extension.ts`)

- `WAVE_DASH_CHAR` の定義箇所: VS CodeのEUC-JPコーデックの挙動(`0xA1 0xC1` も `0x8F 0xA2 0xB7` も等しく `U+FF5E` にデコードされ、`U+301C` はエンコードすると `?` になる)と、それでもカウント処理を残している理由を説明。前提を固定しているテストファイルへのポインタも記載
- `countSpecificCharacters` のJSDoc: EUC-JPでは `U+301C` の項が常に0件で変換の前後でカウントが変化しないことを1行で述べ、詳細は定義箇所を参照させる

### 新規テスト (`src/test/suite/eucjp-encoding-invariants.test.ts`)

`vscode.workspace.decode` / `vscode.workspace.encode` に `encoding: "eucjp"` を明示して、以下5件を検証する。将来VS Code側のコーデック実装が変わってこの前提が崩れた場合に検知できる。

1. 波ダッシュのバイト列 `0xA1 0xC1` は `U+FF5E` にデコードされ、`U+301C` にはならない
2. 全角チルダのバイト列 `0x8F 0xA2 0xB7` も `U+FF5E` にデコードされる
3. `U+FF5E` をエンコードすると `0x8F 0xA2 0xB7` になる
4. `U+301C` はEUC-JPで表現できず `0x3F`(`"?"`)にエンコードされる
5. `0xA1 0xC1` と `0x8F 0xA2 0xB7` を混在させたバイト列をデコードすると `U+301C` は含まれず、`countSpecificCharacters` の結果が全角チルダの出現回数と完全に一致する(= `WAVE_DASH_CHAR` 分の寄与が0件である)

なお、実ファイル経由のデコード(`0xA1 0xC1` を含むEUC-JPファイル → `document.getText()` に `U+FF5E`)は既存の `already-converted bytes decode back to the target codepoints` テストで既に固定されているため、重複させていない。

## 実測で分かったこと(issueの記述への補足)

issueに記載されていた事実は両方とも確認できた:

- `decode(0xA1 0xC1, eucjp)` → `U+FF5E`(`U+301C` ではない)
- `encode(U+301C, eucjp)` → `0x3F`

これに加えて、当初 `encode(U+FF5E, eucjp)` は `0xA1 0xC1` になると想定してテストを書いたところ失敗し、実際には **3バイトのSS3形式 `0x8F 0xA2 0xB7`** が返ることが分かった。つまりVS CodeのEUC-JPコーデックは非対称で、`0xA1 0xC1` と `0x8F 0xA2 0xB7` の両方が `U+FF5E` にデコードされる一方、`U+FF5E` のエンコード結果は常に3バイト側になる。デコードとエンコードを往復しても `0xA1 0xC1` は得られないため、文字列の再エンコードでは全角チルダ→波ダッシュの変換を実現できない。

この期待値は同時に「`eucjp` が本当に使われているか」の対照実験にもなっている。未対応のエンコーディング名を渡すとVS Codeは既定のエンコーディングにフォールバックする仕様のため、もしUTF-8にフォールバックしていれば `0xEF 0xBD 0x9E` が返ってこのテストが落ちる。

## 検証結果

- `npm run lint`: pass
- `npm run format-check`: pass (All matched files use Prettier code style)
- `npm run spellcheck`: pass (Files checked: 44, Issues found: 0)
- `npm test`: **29 passing / 0 failing**(新規5件を含む。既存テストは無変更で全て通過)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
