### PR TITLE
refactor: 変換対象をCONVERT_TARGETSテーブルに集約して二重管理を解消する

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,37 @@ const WAVE_DASH_CHAR = String.fromCodePoint(WAVEDASH_CODE_POINT);
 const FULLWIDTH_TILDE_CHAR = String.fromCodePoint(FULLWIDTH_TILDE_CODE_POINT);
 const NUMERO_SIGN_CHAR = String.fromCodePoint(NUMERO_SIGN_CODE_POINT);
 
+/**
+ * 変換対象の一覧
+ *
+ * 「何を変換するか」の唯一の定義。Unicode文字での判定
+ * (containsConvertTargetCharacters)とバイト列での変換
+ * (replaceSpecificCharactersInBuffer)の両方をこのテーブルから駆動するため、
+ * 変換対象を増やすときはここに1エントリ追加するだけで両方に反映される
+ *
+ * 各エントリは以下を満たす必要がある(replaceSpecificCharactersInBufferの
+ * 実装がこれらに依存している)
+ * - fromはEUC-JPのSS3バイト(0x8F)で始まる: SS3の位置だけをindexOfで走査して
+ *   候補位置を絞るため
+ * - to.length <= from.length: 出力用Bufferを入力と同じ長さで確保するため
+ */
+export const CONVERT_TARGETS = [
+  {
+    char: FULLWIDTH_TILDE_CHAR,
+    configKey: "fullwidthTildeToWaveDash",
+    from: [0x8f, 0xa2, 0xb7], // 全角チルダ
+    to: [0xa1, 0xc1], // 波ダッシュ
+  },
+  {
+    char: NUMERO_SIGN_CHAR,
+    configKey: "numeroSignToNumeroSign",
+    from: [0x8f, 0xa2, 0xf1], // 全角NO
+    to: [0xad, 0xe2], // 全角NO
+  },
+] as const;
+
+type ConvertTarget = (typeof CONVERT_TARGETS)[number];
+
 // ステータスバー更新のデバウンス時間(ms)
 // キーストロークのたびに全文スキャンが走らないように、この時間内の連続更新要求を1回にまとめる
 const STATUS_BAR_UPDATE_DEBOUNCE_MS = 200;
@@ -481,31 +512,27 @@ async function syncEditorWithConvertedFile(document: vscode.TextDocument) {
 }
 
 /**
- * 変換対象文字(全角チルダ、全角NO)ごとの有効/無効設定を返す
+ * 設定で変換が有効になっている変換対象を返す
  *
  * containsConvertTargetCharactersとreplaceSpecificCharactersInBufferの
  * 両方で同じ設定を読むため、読み込み処理を共通化する
  *
- * @returns 各変換対象文字の有効/無効設定
+ * @returns 有効な変換対象の一覧(すべて無効なら空配列)
  */
-function getConvertTargetConfig(): {
-  convertsFullwidthTilde: boolean;
-  convertsNumeroSign: boolean;
-} {
+function getConvertTargetConfig(): ConvertTarget[] {
   const config = vscode.workspace.getConfiguration("waveDashUnify");
 
-  return {
-    convertsFullwidthTilde: config.get("fullwidthTildeToWaveDash") as boolean,
-    convertsNumeroSign: config.get("numeroSignToNumeroSign") as boolean,
-  };
+  return CONVERT_TARGETS.filter(
+    (target) => config.get<boolean>(target.configKey) === true,
+  );
 }
 
 /**
- * ドキュメントに変換対象文字(全角チルダ、全角NO)が含まれるかを判定する
+ * ドキュメントに変換対象文字(CONVERT_TARGETSのchar)が含まれるかを判定する
  *
  * 設定で変換が無効化されている文字は判定対象に含めない
  * (例: fullwidthTildeToWaveDashがfalseなら全角チルダの有無は見ない)。
- * 両方の設定がfalseの場合は変換が絶対に起きないため、document.getText()
+ * すべての設定がfalseの場合は変換が絶対に起きないため、document.getText()
  * (全文のUTF-16コピーを作る)を呼ばずに終了する
  *
  * @param document 判定対象のドキュメント(保存直後のものを想定)
@@ -514,24 +541,15 @@ function getConvertTargetConfig(): {
 export function containsConvertTargetCharacters(
   document: vscode.TextDocument,
 ): boolean {
-  const { convertsFullwidthTilde, convertsNumeroSign } =
-    getConvertTargetConfig();
+  const targets = getConvertTargetConfig();
 
-  if (!convertsFullwidthTilde && !convertsNumeroSign) {
+  if (targets.length === 0) {
     return false;
   }
 
   const text = document.getText();
 
-  if (convertsFullwidthTilde && text.includes(FULLWIDTH_TILDE_CHAR)) {
-    return true;
-  }
-
-  if (convertsNumeroSign && text.includes(NUMERO_SIGN_CHAR)) {
-    return true;
-  }
-
-  return false;
+  return targets.some((target) => text.includes(target.char));
 }
 
 /**
@@ -560,26 +578,48 @@ export function isEUCJP(str: vscode.TextDocument): boolean {
 }
 
 /**
- * 与えられた文字列中の特定文字を置き換えた文字列を返す
- * 置き換える文字は以下
- * | 置き換え前                  | 置き換え後             |
- * | --------------------------- | ---------------------- |
- * | 全角チルダ (0x8F 0xA2 0xB7) | 波ダッシュ (0xA1 0xC1) |
- * | 全角NO     (0x8F 0xA2 0xF1) | 全角NO     (0xAD 0xE2) |
+ * バッファの指定位置がバイト列と一致するかを判定する
  *
- * @param str 変換したい文字列
- * @returns 変換後の文字列
+ * @param str 検索対象のバッファ
+ * @param position 比較を開始する位置
+ * @param bytes 一致を確認するバイト列
+ * @returns `true`: positionからbytesと一致する, `false`: 一致しない
+ */
+function matchesBytesAt(
+  str: Buffer,
+  position: number,
+  bytes: readonly number[],
+): boolean {
+  if (position + bytes.length > str.length) {
+    return false;
+  }
+
+  for (let offset = 0; offset < bytes.length; offset++) {
+    if (str[position + offset] !== bytes[offset]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * 与えられたバッファ中の特定のバイト列を置き換えたバッファを返す
+ *
+ * 置き換える対象はCONVERT_TARGETS(設定で有効なものだけ)
+ *
+ * @param str 変換したいバッファ
+ * @returns 変換後のバッファ(変換対象が1つも無ければ引数のバッファそのもの)
  */
 export function replaceSpecificCharactersInBuffer(str: Buffer): Buffer {
-  const { convertsFullwidthTilde, convertsNumeroSign } =
-    getConvertTargetConfig();
+  const targets = getConvertTargetConfig();
 
-  if (!convertsFullwidthTilde && !convertsNumeroSign) {
+  if (targets.length === 0) {
     return str;
   }
 
-  // 変換対象はいずれも 0x8F 0xA2 で始まる3バイト列のため、
-  // ネイティブ実装で高速な indexOf で先頭バイトの候補位置だけを走査する
+  // 変換対象のバイト列はいずれもSS3で始まるため、ネイティブ実装で高速な
+  // indexOfでSS3の位置だけを走査し、その候補位置でのみバイト列を比較する
   const SS3 = 0x8f; // EUC-JPのシングルシフト(SS3)バイト。変換対象の先頭バイト
 
   let converted: Buffer | undefined;
@@ -587,28 +627,24 @@ export function replaceSpecificCharactersInBuffer(str: Buffer): Buffer {
   let copiedPos = 0; // strのコピー済み位置
   let i = str.indexOf(SS3);
 
-  while (i !== -1 && i + 2 < str.length) {
-    let replacement: [number, number] | undefined;
+  while (i !== -1) {
+    const position = i;
+    const target = targets.find((candidate) =>
+      matchesBytesAt(str, position, candidate.from),
+    );
 
-    if (str[i + 1] === 0xa2) {
-      if (convertsFullwidthTilde && str[i + 2] === 0xb7) {
-        replacement = [0xa1, 0xc1]; // 全角チルダ -> 波ダッシュ
-      } else if (convertsNumeroSign && str[i + 2] === 0xf1) {
-        replacement = [0xad, 0xe2]; // 全角NO -> 全角NO
-      }
-    }
-
-    if (replacement) {
-      // 3バイトを2バイトに置き換えるため、変換後は元の長さを超えない
+    if (target) {
+      // to.length <= from.lengthのため、変換後は元の長さを超えない
       converted ??= Buffer.allocUnsafe(str.length);
 
-      writePos += str.copy(converted, writePos, copiedPos, i);
-      converted[writePos++] = replacement[0];
-      converted[writePos++] = replacement[1];
-      copiedPos = i + 3;
+      writePos += str.copy(converted, writePos, copiedPos, position);
+      for (const byte of target.to) {
+        converted[writePos++] = byte;
+      }
+      copiedPos = position + target.from.length;
       i = str.indexOf(SS3, copiedPos);
     } else {
-      i = str.indexOf(SS3, i + 1);
+      i = str.indexOf(SS3, position + 1);
     }
   }
 

--- a/src/test/suite/convert-targets-table.test.ts
+++ b/src/test/suite/convert-targets-table.test.ts
@@ -1,0 +1,169 @@
+import * as assert from "assert";
+import * as extension from "../../extension";
+
+import * as vscode from "vscode";
+
+/**
+ * CONVERT_TARGETSのテーブルが変換対象の単一の定義源になっていることを検証する
+ *
+ * containsConvertTargetCharacters(Unicode文字での判定)と
+ * replaceSpecificCharactersInBuffer(バイト列での変換)は同じテーブルから
+ * 駆動されるべきものだが、片方にだけ変換対象が追加されても
+ * 「新しい変換が静かに一切効かない」という形でしか現れず気付きにくい(issue #634)。
+ *
+ * このテストはCONVERT_TARGETSを走査して両方の関数を確認するため、
+ * テーブルにエントリを追加すれば自動的にそのエントリも検証対象になる
+ */
+suite("Convert Targets Table Test Suite", () => {
+  // 同じ設定キーを複数のエントリが共有していても1回だけ更新すればよい
+  const configKeys = [
+    ...new Set(extension.CONVERT_TARGETS.map((target) => target.configKey)),
+  ];
+
+  /**
+   * 変換対象の有効/無効設定をまとめて更新する
+   *
+   * @param value 設定値(undefinedでデフォルトに戻す)
+   */
+  async function updateAllConfigs(value: boolean | undefined) {
+    const config = vscode.workspace.getConfiguration("waveDashUnify");
+
+    await Promise.all(
+      configKeys.map((configKey) =>
+        config.update(configKey, value, vscode.ConfigurationTarget.Global),
+      ),
+    );
+  }
+
+  /**
+   * 変換対象文字を含むドキュメントを作る
+   *
+   * containsConvertTargetCharactersはdocument.getText()だけを見る
+   * (EUC-JPかどうかの判定は呼び出し側の責務)ため、
+   * 一時ファイルやエンコーディングの自動判定は不要
+   *
+   * @param char ドキュメントに含める文字
+   * @returns 生成したドキュメント
+   */
+  async function openDocumentContaining(
+    char: string,
+  ): Promise<vscode.TextDocument> {
+    return vscode.workspace.openTextDocument({
+      language: "plaintext",
+      content: `あ${char}あ`,
+    });
+  }
+
+  // 他のテストスイートと同じVS Codeインスタンス・同じグローバル設定を共有するため、
+  // このスイートで変更した設定は必ずデフォルトに戻す
+  teardown(async () => {
+    await updateAllConfigs(undefined);
+  });
+
+  /**
+   * replaceSpecificCharactersInBufferの実装が前提にしているテーブルの不変条件を固定する
+   */
+  test("every entry satisfies the assumptions of the byte scan", () => {
+    const SS3 = 0x8f;
+
+    for (const target of extension.CONVERT_TARGETS) {
+      assert.strictEqual(
+        target.from[0],
+        SS3,
+        `変換前のバイト列がSS3で始まっていない: ${target.configKey}`,
+      );
+      assert.ok(
+        target.to.length <= target.from.length,
+        `変換後のバイト列が変換前より長い: ${target.configKey}`,
+      );
+    }
+  });
+
+  /**
+   * テーブルの各エントリが両方の関数に反映されていることを確認する
+   *
+   * 片方の関数にしか反映されていないエントリがあればここで落ちる
+   */
+  test("every enabled entry is detected and converted", async () => {
+    await updateAllConfigs(true);
+
+    for (const target of extension.CONVERT_TARGETS) {
+      const document = await openDocumentContaining(target.char);
+      assert.strictEqual(
+        extension.containsConvertTargetCharacters(document),
+        true,
+        `containsConvertTargetCharactersが変換対象文字を検出しなかった: ${target.configKey}`,
+      );
+
+      const actual = extension.replaceSpecificCharactersInBuffer(
+        Buffer.from([0xa4, 0xa2, ...target.from, 0xa4, 0xa2]),
+      );
+      assert.strictEqual(
+        actual.toString("hex"),
+        Buffer.from([0xa4, 0xa2, ...target.to, 0xa4, 0xa2]).toString("hex"),
+        `replaceSpecificCharactersInBufferが変換しなかった: ${target.configKey}`,
+      );
+    }
+  });
+
+  /**
+   * エントリごとに、その設定キーだけを有効にしても両方の関数に反映されることを確認する
+   *
+   * 設定キーの読み込みがテーブルから駆動されていない(特定のキーを直接読んでいる)場合、
+   * 新しいエントリの設定が無視されるためここで落ちる
+   */
+  test("every entry is driven by its own config key", async () => {
+    for (const target of extension.CONVERT_TARGETS) {
+      await updateAllConfigs(false);
+
+      const config = vscode.workspace.getConfiguration("waveDashUnify");
+      await config.update(
+        target.configKey,
+        true,
+        vscode.ConfigurationTarget.Global,
+      );
+
+      const document = await openDocumentContaining(target.char);
+      assert.strictEqual(
+        extension.containsConvertTargetCharacters(document),
+        true,
+        `設定を有効にしてもcontainsConvertTargetCharactersが検出しなかった: ${target.configKey}`,
+      );
+
+      const actual = extension.replaceSpecificCharactersInBuffer(
+        Buffer.from([...target.from]),
+      );
+      assert.strictEqual(
+        actual.toString("hex"),
+        Buffer.from([...target.to]).toString("hex"),
+        `設定を有効にしてもreplaceSpecificCharactersInBufferが変換しなかった: ${target.configKey}`,
+      );
+    }
+  });
+
+  /**
+   * すべての設定を無効にすると、どのエントリも変換対象と見なされないことを確認する
+   *
+   * 変換対象が1つも無い場合に入力のBufferがそのまま(コピーせず)返る挙動も
+   * ここで固定する(convertSavedFileが参照比較で書き換え不要と判定するため)
+   */
+  test("no entry is a convert target while all configs are disabled", async () => {
+    await updateAllConfigs(false);
+
+    for (const target of extension.CONVERT_TARGETS) {
+      const document = await openDocumentContaining(target.char);
+      assert.strictEqual(
+        extension.containsConvertTargetCharacters(document),
+        false,
+        `設定が無効なのにcontainsConvertTargetCharactersが検出した: ${target.configKey}`,
+      );
+
+      const contents = Buffer.from([...target.from]);
+      assert.strictEqual(
+        extension.replaceSpecificCharactersInBuffer(contents),
+        contents,
+        `設定が無効なのに入力のBufferがそのまま返らなかった: ${target.configKey}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
Closes #634

## 背景

`containsConvertTargetCharacters`(Unicode文字での判定)と `replaceSpecificCharactersInBuffer`(バイト列での変換)が「何を変換するか」を別表現で二重管理していた。3つ目の変換対象をバイト列側にだけ追加すると、`containsConvertTargetCharacters` の早期returnで弾かれて新しい変換が静かに一切効かなくなる。

## 変更内容

- 変換対象を `CONVERT_TARGETS`(`char` / `configKey` / `from` / `to`)の1テーブルで表現し、上記2関数の両方をこのテーブルから駆動するようにした
- バイト列の一致判定を `matchesBytesAt` に切り出し、`from` / `to` の長さに依存しない形にした
- 新規テスト `src/test/suite/convert-targets-table.test.ts` を追加。テーブルを走査して各エントリが両方の関数に反映されていることを確認するため、**エントリを追加すれば自動的に検証対象になる**

### 維持した挙動・性能特性

- すべての設定が無効なら `document.getText()` を呼ばずに早期return する特性
- EUC-JPのSS3バイト(0x8F)の位置だけを `Buffer#indexOf`(ネイティブ実装)で走査する高速パス。全バイトのforループ走査には**していない**
- 変換対象が1つも無い場合に入力の Buffer をそのまま(コピーせず)返す挙動(`convertSavedFile` が参照比較で書き換え不要と判定するため)。新規テストでも identity 比較で固定した
- エクスポートされている関数のシグネチャ(`containsConvertTargetCharacters`, `replaceSpecificCharactersInBuffer`)は変更なし。`src/test/suite/extension.test.ts` は**無変更**

### 注意: `getConvertTargetConfig` の戻り値の型を変更している

- 変更前: `{ convertsFullwidthTilde: boolean; convertsNumeroSign: boolean }` → 変更後: `ConvertTarget[]`(有効な変換対象の一覧)
- 名前と引数(0個)は変更なし。この関数は**エクスポートされていない**module privateな関数で、テストからの参照も無い(grepで確認済み)
- 固定の2フィールドを返す形のままではテーブル駆動にできず(3つ目のエントリの設定が読まれない)、issueのゴールが達成できないため変更した

## 検証結果

- `npm run lint` / `npm run format-check` / `npm run spellcheck`: いずれも通過
- テストスイート(xvfb上のVS Code 1.130.0): **28 passing / 0 failing**。既存 `extension.test.ts` の全テスト(`config enable/disable convert`、`early return respects each setting independently` など)が無変更で通過
- **テーブル1箇所の変更で両方の関数に反映されることの確認**: 一時的に3つ目のエントリ(`from: [0x8f, 0xa2, 0xbd]` → `to: [0xa1, 0xdd]`)をテーブルに追加してテストを実行し、`containsConvertTargetCharacters` がその `char` を検出し、`replaceSpecificCharactersInBuffer` がそのバイト列を変換することを確認した(その後この仮エントリは削除済み。3つ目の実際の追加はこのissueの範囲外)
  - なお仮エントリの `configKey` は既存の `fullwidthTildeToWaveDash` を流用したため、この検証が示すのは「**テーブルの行**を追加すれば両関数に反映される」ことである(新しい**設定キー**が自動で生えることまでは示していない)

## 補足: 実際に3つ目の変換対象を追加するときに必要なもの

`CONVERT_TARGETS` は「検出」と「バイト変換」の単一の定義源になったが、設定そのものは生成しないため、新しい変換対象を追加する際は別途以下が必要になる。

- `package.json` の `contributes.configuration` に `waveDashUnify.*` の設定を追加
- `package.nls.json` / `package.nls.ja.json` に説明文を追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)