### PR TITLE
test: 設定のリセットをsuiteSetupとteardownに移してテスト間の設定リークを解消する

### DIFF
--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -10,11 +10,10 @@ import * as vscode from "vscode";
 suite("Extension Test Suite", () => {
   vscode.window.showInformationMessage("Start all tests.");
 
-  test("Cleanup", async () => {
-    // テスト後にファイルを削除する
-    tmp.setGracefulCleanup();
-
-    // 設定をリセットする
+  /**
+   * このスイートが変更する設定をすべてデフォルト値に戻す
+   */
+  async function resetConfiguration() {
     const config = vscode.workspace.getConfiguration("waveDashUnify");
     const settings = [
       "enableConvert",
@@ -28,6 +27,29 @@ suite("Extension Test Suite", () => {
         config.update(setting, undefined, vscode.ConfigurationTarget.Global),
       ),
     );
+  }
+
+  suiteSetup(async () => {
+    // テスト後にファイルを削除する
+    tmp.setGracefulCleanup();
+
+    // ConfigurationTarget.Globalの書き込みはテスト用のuser-data-dirに残るため、
+    // 前回の実行が中断した場合などは開始時点の設定が既に汚れていることがある。
+    // 1つ目のテストを実行順・過去の実行履歴に依存させないため、ここでも戻す
+    await resetConfiguration();
+  });
+
+  /**
+   * 各テストが変更した設定をデフォルト値に戻す
+   *
+   * 設定をtest()の中で元に戻す方式だと、restoreを書き忘れたテストの影響が
+   * 後続のテストに漏れる。特にfullwidthTildeToWaveDash・numeroSignToNumeroSignが
+   * falseのまま残ると、containsConvertTargetCharactersの早期returnによって
+   * 変換が一切行われなくなり、原因の分かりにくい失敗になる。
+   * teardown()で毎回リセットすることで、テストの実行順に依存しないようにする
+   */
+  teardown(async () => {
+    await resetConfiguration();
   });
 
   /**


### PR DESCRIPTION
Closes #636

## 問題

`src/test/suite/extension.test.ts` の `waveDashUnify.*` 設定がテスト間でリークしていた。

- 設定をリセットする `"Cleanup"` テストは、ファイル内の**最初**に宣言されているため最初にしか実行されない
- `"config enable/disable convert"` テストは末尾で `configuration(false, false)` を呼び、`fullwidthTildeToWaveDash` / `numeroSignToNumeroSign` を **`false` のまま**終了していた(元に戻していない)

現状はmochaのデフォルト実行順(宣言順)のおかげで表面化していないが、実行順が変わる・`test.only` で一部だけ実行する・並列化する、のいずれかが起きると両設定が `false` のまま後続テストが走り、`containsConvertTargetCharacters` の早期returnで変換が一切行われなくなる。

さらに `ConfigurationTarget.Global` の書き込みはテスト用の `.vscode-test/user-data/User/settings.json` に**ファイルとして残る**ため、リークは同一プロセス内に留まらず**次回の実行にも持ち越される**。`"Cleanup"` が偶然最初に実行されることだけが、この持ち越しを打ち消していた。

## 修正

設定リセットを `test()` から**フック**に移し、実行順に依存しない構造にした。

- `teardown()` — **各テストの後に毎回**、`enableConvert` / `fullwidthTildeToWaveDash` / `numeroSignToNumeroSign` / `statusBarFormat` の4つを `undefined`(デフォルト値)に戻す。どのテストが設定を変更しても次のテストには漏れない
- `suiteSetup()` — **スイート開始時にも**同じリセットを行う。`teardown()` は「テストの後」にしか走らないため、これが無いと前回の実行が中断した場合などに、開始時点で既に汚れた設定が1つ目のテストに影響する
- リセット処理は `resetConfiguration()` ヘルパーに切り出して両フックから呼んでいる
- `"Cleanup"` テストは削除した。設定リセットは上記フックが担うようになり、残る役割の `tmp.setGracefulCleanup()` は `suiteSetup()` に移した(これも `"Cleanup"` が最初に実行されることに依存していた同種の暗黙の順序依存だったため、併せて解消)

個別テスト内に手動のリストア処理は追加していない(フックが全テストで効くため)。テスト本体には一切手を入れておらず、順序の変更もしていない。

## 検証

`ConfigurationTarget.Global` の書き込みが `.vscode-test/user-data/User/settings.json` に残る性質を使い、実行順を並べ替えずに `test.only` でリークを再現した(issueが挙げる3つの発火シナリオのうちの1つ)。

### 1. リークの再現(修正前)

`"config enable/disable convert"` のみを `test.only` で実行 → パスし、ディスク上に以下が残った:

```json
{
    "waveDashUnify.fullwidthTildeToWaveDash": false,
    "waveDashUnify.numeroSignToNumeroSign": false
}
```

続けて `"Integration test"` のみを `test.only` で実行(`"Cleanup"` は走らない) → **失敗**。`"Integration test"` は `enableConvert` のみを明示設定し、他2つはデフォルトの `true` に依存しているため:

```
enableConvert: true
before: a4a2a4a2a4a2a4a2
insert: ～№
-8fa2b78fa2f1a4a2a4a2a4a2a4a2  (actual: 変換されていない)
+a1c1ade2a4a2a4a2a4a2a4a2      (expected: 波ダッシュ・全角NOに変換)
```

これはissueが予測した失敗モードそのもの。

### 2. `teardown()` の効果

修正後に `"config enable/disable convert"` のみを `test.only` で実行 → パスし、`settings.json` から `waveDashUnify.*` の4項目がすべて消えた。続けて `"Integration test"` のみを `test.only` で実行 → **パス**。

### 3. `suiteSetup()` の効果(開始時点で汚れている場合)

`settings.json` に上記の `false` 2件を書き込んだ状態から**全テスト**を実行:

| | 結果 |
| --- | --- |
| `teardown()` のみ | **22 passing, 1 failing** — `"Integration test"` が `8fa2b7…` で失敗 |
| `teardown()` + `suiteSetup()` | **23 passing, 0 failing** |

`teardown()` だけでは1つ目のテストを守れないことが確認できたため、`suiteSetup()` でのリセットを追加している。

### 4. 通常の全テスト実行

`23 passing, 0 failing`。`"Cleanup"` テストを削除したため件数は 24 → 23 になっているが、アサーションは失われていない(削除したのは設定リセット処理のみで、それは両フックに移動済み)。

`npm run lint` / `npm run format-check` / `npm run spellcheck` すべてパス。

## 補足

- `teardown()` のスコープは `suite("Extension Test Suite")` 内のみ。`save-conversion.test.ts` は別スイートで、3設定を `true`(= デフォルト値と同じ)にして戻さないが、リークする値が既定と一致するため実害はない。今回のissueの範囲外なので触っていない
- `files.autoGuessEncoding` も `true` のまま残るが、`waveDashUnify.*` 外であり、使う側が毎回明示的に設定し、かつ残る値が許容的な側なので今回は対象外とした
- CIでこの問題が見えなかったのは、CIでは `.vscode-test` が毎回まっさらで、かつ実行順がデフォルトのままだったため

🤖 Generated with [Claude Code](https://claude.com/claude-code)
