### PR TITLE
refactor: runTest.tsのCLI引数解析をyargsからnode:util parseArgsに置き換える

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -61,3 +61,4 @@ jobs:
         if: runner.os == 'Linux'
       - run: npm test -- --vscode-version 1.100.0
         if: runner.os != 'Linux'
+        shell: bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@types/node": "26.x",
         "@types/tmp": "^0.2.6",
         "@types/vscode": "^1.100.0",
-        "@types/yargs": "^17.0.33",
         "@typescript-eslint/eslint-plugin": "^8.65.0",
         "@typescript-eslint/parser": "^8.65.0",
         "@vscode/test-electron": "^2.5.2",
@@ -29,8 +28,7 @@
         "ts-loader": "^9.5.2",
         "typescript": "^5.8.3",
         "webpack": "^5.105.0",
-        "webpack-cli": "^7.2.1",
-        "yargs": "^18.1.0"
+        "webpack-cli": "^7.2.1"
       },
       "engines": {
         "vscode": "^1.100.0"
@@ -1607,23 +1605,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/yargs": {
-      "version": "17.0.35",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
-      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/@types/yargs-parser": {
-      "version": "21.0.3",
-      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
-      "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.65.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
@@ -2901,46 +2882,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/cliui": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
-      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^7.2.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/cliui/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/cliui/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8354,24 +8295,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/wrap-ansi": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
-      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.2.1",
-        "string-width": "^7.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
     "node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
@@ -8412,44 +8335,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/emoji-regex": {
-      "version": "10.6.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
-      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi/node_modules/string-width": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^10.3.0",
-        "get-east-asian-width": "^1.0.0",
-        "strip-ansi": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/wrappy": {
@@ -8546,24 +8431,6 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
-    "node_modules/yargs": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
-      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^9.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "string-width": "^8.2.1",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^22.0.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
-      }
-    },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
@@ -8588,33 +8455,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yargs/node_modules/string-width": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
-      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yargs/node_modules/yargs-parser": {
-      "version": "22.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
-      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=23"
       }
     },
     "node_modules/yauzl": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
     "@types/node": "26.x",
     "@types/tmp": "^0.2.6",
     "@types/vscode": "^1.100.0",
-    "@types/yargs": "^17.0.33",
     "@typescript-eslint/eslint-plugin": "^8.65.0",
     "@typescript-eslint/parser": "^8.65.0",
     "@vscode/test-electron": "^2.5.2",
@@ -100,7 +99,6 @@
     "ts-loader": "^9.5.2",
     "typescript": "^5.8.3",
     "webpack": "^5.105.0",
-    "webpack-cli": "^7.2.1",
-    "yargs": "^18.1.0"
+    "webpack-cli": "^7.2.1"
   }
 }

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,4 +1,5 @@
 import * as path from "path";
+import { parseArgs } from "node:util";
 
 import {
   runTests,
@@ -6,42 +7,37 @@ import {
   TestOptions,
 } from "@vscode/test-electron";
 
-// yargs 18 は CJS 向け export を持たない ESM 専用パッケージになった。
-// tsconfig.json の "module": "commonjs" のもとで `import yargs from "yargs"` や
-// `await import("yargs")` を書くと、tsc はそれを `require("yargs")` に変換して
-// しまい、Node の同期 require() では ESM を読み込めず ERR_REQUIRE_ESM で失敗する
-// (Node 20.19 / 22.12 以降の require(esm) サポートがあれば動くこともあるが、
-// 例えば .devcontainer/Dockerfile が使う node:20 系イメージのように、それより
-// 古い Node ではこの方法は使えない)。
-// `Function` 経由で import() を呼び出すことで tsc による書き換えを回避し、
-// Node のバージョンに関わらず動作する本物の非同期 ESM import を発生させる。
-const dynamicImport = new Function(
-  "specifier",
-  "return import(specifier);",
-) as <T>(specifier: string) => Promise<T>;
-
 /**
  * CLI 引数を解析してオプションを取得する
  * @returns {Object} CLI 引数のオプション
  */
-async function parseCliArgs() {
-  const { default: yargs } =
-    await dynamicImport<typeof import("yargs")>("yargs");
-  const { hideBin } =
-    await dynamicImport<typeof import("yargs/helpers")>("yargs/helpers");
+function parseCliArgs() {
+  const { values } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      // CLI フラグ名 (--vscode-version) は kebab-case である必要があるため、
+      // camelCase を要求する naming-convention の対象から除外する。
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      "vscode-version": { type: "string" },
+      help: { type: "boolean", short: "h" },
+    },
+  });
 
-  const argv = yargs(hideBin(process.argv))
-    .option("vscode-version", {
-      type: "string",
-      description: "VS Code のバージョンを指定",
-    })
-    .help("help")
-    .alias("help", "h")
-    .parseSync();
+  if (values.help) {
+    console.log(
+      [
+        "Usage: npm test -- [options]",
+        "",
+        "Options:",
+        "  --vscode-version <version>  VS Code のバージョンを指定",
+        "  -h, --help                  ヘルプを表示",
+      ].join("\n"),
+    );
+    process.exit(0);
+  }
 
   return {
-    vscodeVersion:
-      typeof argv.vscodeVersion === "string" ? argv.vscodeVersion : undefined,
+    vscodeVersion: values["vscode-version"],
   };
 }
 
@@ -55,7 +51,7 @@ async function main() {
     // Passed to --extensionTestsPath
     const extensionTestsPath = path.resolve(__dirname, "./suite/index");
 
-    const { vscodeVersion } = await parseCliArgs();
+    const { vscodeVersion } = parseCliArgs();
     const options: TestOptions = {
       extensionDevelopmentPath,
       extensionTestsPath,


### PR DESCRIPTION
## Summary
- yargs 18がESM専用パッケージになったため`src/test/runTest.ts`では`new Function`経由の動的importで回避していたが、実際に使っている機能は`--vscode-version`オプション1つとhelp表示のみでyargsの機能は過剰だった
- Node組み込みの`node:util`の`parseArgs`に置き換えることで、ESM回避策ごと削除し、`yargs`/`@types/yargs`への依存を解消(dependabot起因の同種の更新対応コストがなくなる)
- **副産物として、Windows上の`test-minimum-vscode-version`ジョブが潜在的に壊れていたことが発覚し、合わせて修正した**: pwsh経由の`npm test -- --vscode-version 1.100.0`は`--`が握りつぶされ、実際には`node runTest.js 1.100.0`のようにpositional引数しか渡っていなかった。yargsはpositional引数を暗黙に無視するため`vscodeVersion`が`undefined`になり、Windows上ではこのジョブが導入されて以来ずっと最小サポートバージョン(1.100.0)ではなく最新安定版(直近の実行では1.130.0)がテストされていた(mainの直近実行ログで確認済み)。`parseArgs`の`strict: true`がこれを例外として顕在化させたため、Windows/macOSの該当stepに`shell: bash`を追加して`--`が正しく渡るようにした。

## Test plan
- [x] `npm run compile-tests` / `npm run lint` / `npx prettier --check` が通ることを確認
- [x] `node ./out/test/runTest.js --help` / `-h` が期待通りusageを表示することを確認
- [x] 未知オプション指定時に`ERR_PARSE_ARGS_UNKNOWN_OPTION`で検出されることを確認(yargsより厳格)
- [x] ヘッドレスVS Code統合テスト(`npm test -- --vscode-version 1.100.0`, bash経由)で実際のダウンロード込みの24件全パスを確認
- [x] CI([test-minimum-vscode-version (windows-latest)](https://github.com/yutotnh/wave-dash-unify/actions))が`shell: bash`修正後に1.100.0を実際にダウンロードしグリーンになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqG2ZGK64BSoZ68i64AxoQ