### PR TITLE
docs: 直近のユーザー向け変更をCHANGELOGのUnreleasedに追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ or each release's GitHub Releases page for those.
 
 ## [Unreleased]
 
+### Added
+
+- Open VSX Registryでの配布に対応しました。VSCodiumなど、Open VSXを利用するエディターにもインストールできるようになりました。([#642](https://github.com/yutotnh/wave-dash-unify/pull/642))
+
+### Changed
+
+- 変換処理を高速化し、大きなファイルを保存する際の遅延を大幅に軽減しました。([#627](https://github.com/yutotnh/wave-dash-unify/pull/627), [#633](https://github.com/yutotnh/wave-dash-unify/pull/633))
+- ステータスバーの文字数カウントの更新をデバウンスし、大きなファイルの編集中の負荷を軽減しました。([#632](https://github.com/yutotnh/wave-dash-unify/pull/632))
+
+### Fixed
+
+- ファイルを連続して素早く保存したときに、拡張機能による変換とVS Codeの保存が競合し、変換結果が反映されないことがある問題を修正しました。([#628](https://github.com/yutotnh/wave-dash-unify/pull/628))
+
 ## [0.4.1] - 2025-05-10
 
 ### Changed


### PR DESCRIPTION
## Issue

- #643 の後続(#646 への追記)

## 対応内容

#646 で `CHANGELOG.md` をKeep a Changelog形式に整理したが、`[Unreleased]` が空のままだった。v0.4.1以降に `main` へ入った**ユーザーに影響する変更**を `[Unreleased]` に追記する。

このPRのbaseは #646 のブランチ(`fix/643-changelog-cleanup`)で、#646 への追記として重ねている。

追記したエントリ(#646 の運用方針に沿って、依存関係バンプ・内部限定の変更(リファクタリング/テスト/CI)は除外):

### Added

- Open VSX Registryでの配布に対応 ([#642](https://github.com/yutotnh/wave-dash-unify/pull/642))

### Changed

- 変換処理の高速化 ([#627](https://github.com/yutotnh/wave-dash-unify/pull/627), [#633](https://github.com/yutotnh/wave-dash-unify/pull/633))
- ステータスバー更新のデバウンス ([#632](https://github.com/yutotnh/wave-dash-unify/pull/632))

### Fixed

- 連続保存時に変換結果が反映されないことがある問題 ([#628](https://github.com/yutotnh/wave-dash-unify/pull/628), Closes #13)

## テスト

ドキュメントのみの変更のため、テストは追加していない。以下を確認済み:

- `npx prettier --check CHANGELOG.md` : 通過
- `npx cspell CHANGELOG.md` : 通過(Issues found: 0)

## 残作業

- #646 がマージされた後は、このPRのbaseを `main` に切り替える(または #646 に直接取り込む)。

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ST7cSfBkZurQKarjCtY6Gh

---
_Generated by [Claude Code](https://claude.ai/code/session_01ST7cSfBkZurQKarjCtY6Gh)_