### PR TITLE
README.mdにOpen VSXへのインストールリンクを復元

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ VS Code ではファイルの文字コードに EUC-JP を指定した状態で`
 
 ## Installation
 
-[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=yutotnh.wave-dash-unify) からインストールできます。
+[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=yutotnh.wave-dash-unify) または [Open VSX Registry](https://open-vsx.org/extension/yutotnh/wave-dash-unify) からインストールできます。
 
 VS Code の拡張機能ビューで `wave-dash-unify` を検索してインストールすることもできます。
 


### PR DESCRIPTION
## Issue

- #668 (フォローアップ)

## 対応内容

#667 のマージ時点では Open VSX Registry への公開がまだ完了していなかった(`CHANGELOG.md` の対応エントリが `[Unreleased]` のままだった)ため、`## Installation` から Open VSX へのリンクを削除していました。

Open VSX への登録準備が整い、次回リリース以降は実際に公開される見込みとのことなので、削除していたリンクを復元します。

- `## Installation` に Open VSX Registry へのリンクを再度追加しました。

## テスト

- `npx prettier --check README.md` でフォーマットが崩れていないことを確認しました。
- `npx cspell README.md` でスペルチェックを実施し、問題無いことを確認しました。

## 残作業

- なし

---
_Generated by [Claude Code](https://claude.ai/code/session_018cuehY2LLTjwJjCMdZX8tz)_