### PR TITLE
build(deps-dev): typescriptを@typescript/typescript6(6.0.2)経由に更新する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,15 @@ updates:
       - dependency-name: "mocha"
         update-types: ["version-update:semver-major"]
 
+      # TypeScript 7 (the native/Go "tsgo" rewrite) is not yet supported by
+      # the rest of the toolchain: @typescript-eslint's peer dependency caps
+      # typescript at <6.1.0 (no compatible release exists, even canary), and
+      # ts-loader crashes calling the native compiler's host APIs. Stay on
+      # 6.x until @typescript-eslint and ts-loader ship majors that support
+      # TypeScript 7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+
   - package-ecosystem: "github-actions"
     directory: "/" # Location of package manifests
     schedule:

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "prettier": "^3.5.3",
         "tmp": "^0.2.7",
         "ts-loader": "^9.5.2",
-        "typescript": "^5.8.3",
+        "typescript": "^6.0.3",
         "webpack": "^5.109.2",
         "webpack-cli": "^7.2.2"
       },
@@ -7994,9 +7994,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "prettier": "^3.5.3",
     "tmp": "^0.2.7",
     "ts-loader": "^9.5.2",
-    "typescript": "^5.8.3",
+    "typescript": "^6.0.3",
     "webpack": "^5.109.2",
     "webpack-cli": "^7.2.2"
   }

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import * as Mocha from "mocha";
+import Mocha from "mocha";
 
 /**
  * ディレクトリを再帰的に走査してテストファイルを集める

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
     "lib": ["ES2020"],
     "sourceMap": true,
     "rootDir": "src",
-    "strict": true /* enable all strict type-checking options */
+    "strict": true /* enable all strict type-checking options */,
+    "esModuleInterop": true,
+    "types": ["node", "mocha"]
     /* Additional Checks */
     // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */


### PR DESCRIPTION
Closes #671

## Summary

dependabot PR #652 は `typescript` を 5.9.3 → 7.0.2 に更新する提案でしたが、検証の結果マージ不可な実ブロッカーが2つ見つかりました(詳細は #671)。

- `@typescript-eslint/eslint-plugin` ・`@typescript-eslint/parser`(最新8.65.0、canary含む)の peer dependency が `typescript: ">=4.8.4 <6.1.0"` に固定されており、7.x系に対応したリリースが存在しないため `npm ci` が ERESOLVE で失敗する。
- `ts-loader`(最新9.6.2)が TS7 のネイティブコンパイラのホストAPI呼び出しでクラッシュする(`TypeError: Cannot read properties of undefined (reading 'fileExists')`)。ソース側の修正では回避不能。

7.0.2 は見送りつつ、`typescript` を直接6.0.3へ更新します。

- 6.1.x系は本家 `typescript` パッケージに一件も存在せず(6.0.3の次はいきなり7.0.1-rc/7.0.2)、6.0.3は `@typescript-eslint` のpeer dependency上限(`<6.1.0`)を満たすため、特別な回避策(alias installなど)なしに `npm ci` が通ります。
- `package.json`: `typescript` を `"^6.0.3"` に更新
- `tsconfig.json`: `esModuleInterop: true` と明示的な `types: ["node", "mocha"]` を追加(TypeScript 6以降、`@types/node` の暗黙解決と `export =` 形式クラスのnamespace import扱いが変わったための対応)
- `src/test/suite/index.ts`: `import * as Mocha` → `import Mocha`(esModuleInterop有効化に伴う修正)
- `.github/dependabot.yml`: 既存の `@types/node` ・`mocha` と同様に、`typescript` のメジャー更新(7.x系)のみを無視するルールを追加

「コンパイル時に警告が出る」という懸念について: 上記2点のtsconfig/import修正を入れた状態で `tsc` ・`eslint` ・`webpack`(ts-loader)を実行しましたが、TypeScript由来の警告・エラーは **0件** でした(修正前は `Buffer`/`fs`/`path`/`setTimeout`/`console` 等のグローバル型が解決できない型エラーが出ていましたが、いずれも上記のtsconfig修正で解消し、抑制ではなくソース側の修正で解決しています)。

`typescript@7.0.2` そのものへの更新、および `@typescript-eslint` ・`ts-loader` 自体のメジャーアップグレードは今回のスコープ外です(対応バージョンが存在しないため)。

## Test plan

- [x] `npm ci` (peer dependency エラーが出ないことを確認)
- [x] `npm run compile-tests`
- [x] `npm run compile` (webpack)
- [x] `npm run lint`
- [x] `npm run format-check`
- [x] `npm run spellcheck`
- [x] `npm test` (Electron版) はサンドボックス環境から `update.code.visualstudio.com` に到達できずローカル実行不可(#627, #654 既知の制約)。3 OSマトリクスのCIで確認します。

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhZJYEiRRnusRVCYEoghzy)_