### PR TITLE
build(deps-dev): package.jsonのoverridesをmochaスコープに限定する

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,9 +103,11 @@
     "webpack-cli": "^7.2.2"
   },
   "overrides": {
-    "brace-expansion": "^5.0.9",
-    "diff": "^9.0.0",
-    "minimatch": "^10.2.5",
-    "serialize-javascript": "^7.0.7"
+    "mocha": {
+      "brace-expansion": "^5.0.9",
+      "diff": "^9.0.0",
+      "minimatch": "^10.2.5",
+      "serialize-javascript": "^7.0.7"
+    }
   }
 }


### PR DESCRIPTION
## 概要

closes #676

#674 で追加した `overrides` がパッケージ名のみを指定する非スコープ形式だったため、依存ツリー全体の同名パッケージ(`brace-expansion`/`diff`/`minimatch`/`serialize-javascript`)に強制適用されていた。現状は他のdevDependencyと衝突していないため無害だが、将来別の依存が異なるバージョン範囲を要求した場合に非互換が再発するリスクがある。

実際、#674の作業中に一度 `brace-expansion` だけを5系にoverrideした際、mocha配下の古い `minimatch@9.0.9` が壊れた実例がある(`TypeError: (0 , brace_expansion_1.default) is not a function`)。この影響範囲を絞るため、mocha配下にのみ適用されるネスト形式に変更する。

## 変更内容

```diff
 "overrides": {
-  "brace-expansion": "^5.0.9",
-  "diff": "^9.0.0",
-  "minimatch": "^10.2.5",
-  "serialize-javascript": "^7.0.7"
+  "mocha": {
+    "brace-expansion": "^5.0.9",
+    "diff": "^9.0.0",
+    "minimatch": "^10.2.5",
+    "serialize-javascript": "^7.0.7"
+  }
 }
```

package-lock.jsonは変化なし(overridesはlockfileに記録されない仕様のため、解決される実バージョンが同じであれば差分は出ない)。

## 検証

- `npm audit`: 0 vulnerabilities
- `rm -rf node_modules && npm install` → 0 vulnerabilities
- `npm run lint` / `format-check` / `spellcheck` / `compile-tests` / `compile`: 全て通過
- サンドボックス環境では `npm test`(Electron版)がローカル実行不可のため、mocha自体を直接動かして検証:
  - 意図的に失敗させたテストで `diff`(9.x)による差分表示が正常
  - 本リポジトリの実際の経路(`new Mocha()` + `addFile()`、`src/test/suite/index.ts`と同じ形)で`out/test/suite/debounce.test.js`を実行し、4件成功を確認
- CIの3 OSマトリクスで最終確認予定

## Test plan

- [ ] CI(3 OSマトリクス)のテストが通ることを確認