### PR TITLE
chore: tsconfig.jsonの追加strictフラグを有効化

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,10 +5,16 @@
     "lib": ["ES2020"],
     "sourceMap": true,
     "rootDir": "src",
-    "strict": true /* enable all strict type-checking options */
+    "strict": true, /* enable all strict type-checking options */
     /* Additional Checks */
     // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
     // "noUnusedParameters": true,  /* Report errors on unused parameters. */
+    "noImplicitOverride": true, /* Ensure overriding members in derived classes are marked with an override modifier. */
+    "noUnusedLocals": true, /* Report errors on unused locals. */
+    "noPropertyAccessFromIndexSignature": true, /* Require undeclared properties from index signatures to use element accesses. */
+    "useUnknownInCatchVariables": true, /* Type catch clause variables as unknown instead of any. */
+    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
+    "exactOptionalPropertyTypes": true /* Interpret optional property types as written, rather than adding undefined. */
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "noImplicitOverride": true, /* Ensure overriding members in derived classes are marked with an override modifier. */
     "noUnusedLocals": true, /* Report errors on unused locals. */
     "noPropertyAccessFromIndexSignature": true, /* Require undeclared properties from index signatures to use element accesses. */
-    "useUnknownInCatchVariables": true, /* Type catch clause variables as unknown instead of any. */
     "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
     "exactOptionalPropertyTypes": true /* Interpret optional property types as written, rather than adding undefined. */
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,15 +5,14 @@
     "lib": ["ES2020"],
     "sourceMap": true,
     "rootDir": "src",
-    "strict": true, /* enable all strict type-checking options */
+    "strict": true /* enable all strict type-checking options */,
     /* Additional Checks */
     // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
     // "noUnusedParameters": true,  /* Report errors on unused parameters. */
-    "noImplicitOverride": true, /* Ensure overriding members in derived classes are marked with an override modifier. */
-    "noUnusedLocals": true, /* Report errors on unused locals. */
-    "noPropertyAccessFromIndexSignature": true, /* Require undeclared properties from index signatures to use element accesses. */
-    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
+    "noImplicitOverride": true /* Ensure overriding members in derived classes are marked with an override modifier. */,
+    "noUnusedLocals": true /* Report errors on unused locals. */,
+    "noPropertyAccessFromIndexSignature": true /* Require undeclared properties from index signatures to use element accesses. */,
     "exactOptionalPropertyTypes": true /* Interpret optional property types as written, rather than adding undefined. */
   }
 }


### PR DESCRIPTION
## 何をしたか

issue #672(`noImplicitReturns`/`noFallthroughCasesInSwitch`/`noUnusedParameters`)とは別に、`tsconfig.json`にまだ有効化していなかった追加のstrict系フラグを有効化した。

- `noImplicitOverride`
- `noUnusedLocals`
- `noPropertyAccessFromIndexSignature`
- `exactOptionalPropertyTypes`

コード変更はなく、`tsconfig.json`のみの変更。

## 影響確認

有効化前に`src`配下全体に対して個別・組み合わせの両方で影響を確認し、いずれもエラー0件だった。

```
npx tsc -p . --noEmit --noImplicitOverride --noUnusedLocals --noPropertyAccessFromIndexSignature --exactOptionalPropertyTypes
```

途中経緯として、当初`useUnknownInCatchVariables`と`forceConsistentCasingInFileNames`も候補に含めていたが、どちらも実際には無意味な指定だったため除外した:

- `useUnknownInCatchVariables`はTypeScript 4.4以降`strict: true`に含まれるフラグで、既に有効
- `forceConsistentCasingInFileNames`はTypeScript 4.7以降デフォルトで`true`

いずれもTypeScriptコンパイラAPI(`ts.optionDeclarations`)や実際の挙動で確認済み。

## テスト

`npm run compile-tests` / `npm run compile` / `npm run lint` / `npm run format-check` / `npm run spellcheck`を確認。

`npm test`(Electron版)もNix経由のxvfb-run + NSS/NSPRでローカルにヘッドレス実行し、38件パスを確認した。CI(3 OSマトリクス)でもあわせて確認する。
