### PR TITLE
fix: noUncheckedIndexedAccessを有効化し未チェックなインデックスアクセスを修正する

### DIFF
--- a/src/eucjp.ts
+++ b/src/eucjp.ts
@@ -54,21 +54,23 @@ export type EucjpVerdict = true | false | "unknown";
  * JIS X 0208(2バイト)とJIS X 0212(SS3 + 2バイト)のどちらの後続バイトも
  * この範囲に収まる
  *
- * @param byte 判定するバイト
- * @returns `true`: 0xA1〜0xFEの範囲内, `false`: 範囲外
+ * @param byte 判定するバイト。呼び出し側でバッファ末尾チェックをしているため
+ *   実際には`undefined`にはならないが、`buffer[i]`の型に合わせている
+ * @returns `true`: 0xA1〜0xFEの範囲内, `false`: 範囲外(`undefined`を含む)
  */
-function isDoubleByteRange(byte: number): boolean {
-  return byte >= 0xa1 && byte <= 0xfe;
+function isDoubleByteRange(byte: number | undefined): boolean {
+  return byte !== undefined && byte >= 0xa1 && byte <= 0xfe;
 }
 
 /**
  * SS2に続く半角カナのバイトかを判定する
  *
- * @param byte 判定するバイト
- * @returns `true`: 0xA1〜0xDFの範囲内, `false`: 範囲外
+ * @param byte 判定するバイト。呼び出し側でバッファ末尾チェックをしているため
+ *   実際には`undefined`にはならないが、`buffer[i]`の型に合わせている
+ * @returns `true`: 0xA1〜0xDFの範囲内, `false`: 範囲外(`undefined`を含む)
  */
-function isHalfwidthKatakanaByte(byte: number): boolean {
-  return byte >= 0xa1 && byte <= 0xdf;
+function isHalfwidthKatakanaByte(byte: number | undefined): boolean {
+  return byte !== undefined && byte >= 0xa1 && byte <= 0xdf;
 }
 
 /**
@@ -120,6 +122,12 @@ export function isEUCJPBuffer(buffer: Buffer): boolean {
 
   while (position < buffer.length) {
     const byte = buffer[position];
+
+    // while条件(position < buffer.length)により実際には到達しないが、
+    // noUncheckedIndexedAccessを満たすために必要
+    if (byte === undefined) {
+      return false;
+    }
 
     // ASCII(制御文字を含む)
     if (byte <= 0x7f) {

--- a/src/eucjp.ts
+++ b/src/eucjp.ts
@@ -54,23 +54,21 @@ export type EucjpVerdict = true | false | "unknown";
  * JIS X 0208(2バイト)とJIS X 0212(SS3 + 2バイト)のどちらの後続バイトも
  * この範囲に収まる
  *
- * @param byte 判定するバイト。呼び出し側でバッファ末尾チェックをしているため
- *   実際には`undefined`にはならないが、`buffer[i]`の型に合わせている
- * @returns `true`: 0xA1〜0xFEの範囲内, `false`: 範囲外(`undefined`を含む)
+ * @param byte 判定するバイト
+ * @returns `true`: 0xA1〜0xFEの範囲内, `false`: 範囲外
  */
-function isDoubleByteRange(byte: number | undefined): boolean {
-  return byte !== undefined && byte >= 0xa1 && byte <= 0xfe;
+function isDoubleByteRange(byte: number): boolean {
+  return byte >= 0xa1 && byte <= 0xfe;
 }
 
 /**
  * SS2に続く半角カナのバイトかを判定する
  *
- * @param byte 判定するバイト。呼び出し側でバッファ末尾チェックをしているため
- *   実際には`undefined`にはならないが、`buffer[i]`の型に合わせている
- * @returns `true`: 0xA1〜0xDFの範囲内, `false`: 範囲外(`undefined`を含む)
+ * @param byte 判定するバイト
+ * @returns `true`: 0xA1〜0xDFの範囲内, `false`: 範囲外
  */
-function isHalfwidthKatakanaByte(byte: number | undefined): boolean {
-  return byte !== undefined && byte >= 0xa1 && byte <= 0xdf;
+function isHalfwidthKatakanaByte(byte: number): boolean {
+  return byte >= 0xa1 && byte <= 0xdf;
 }
 
 /**
@@ -137,10 +135,8 @@ export function isEUCJPBuffer(buffer: Buffer): boolean {
 
     // 半角カナ: SS2 + 1バイト
     if (byte === SS2) {
-      if (
-        position + 1 >= buffer.length ||
-        !isHalfwidthKatakanaByte(buffer[position + 1])
-      ) {
+      const next = buffer[position + 1];
+      if (next === undefined || !isHalfwidthKatakanaByte(next)) {
         return false;
       }
 
@@ -150,10 +146,13 @@ export function isEUCJPBuffer(buffer: Buffer): boolean {
 
     // 補助漢字: SS3 + 2バイト
     if (byte === SS3) {
+      const next1 = buffer[position + 1];
+      const next2 = buffer[position + 2];
       if (
-        position + 2 >= buffer.length ||
-        !isDoubleByteRange(buffer[position + 1]) ||
-        !isDoubleByteRange(buffer[position + 2])
+        next1 === undefined ||
+        next2 === undefined ||
+        !isDoubleByteRange(next1) ||
+        !isDoubleByteRange(next2)
       ) {
         return false;
       }
@@ -164,10 +163,8 @@ export function isEUCJPBuffer(buffer: Buffer): boolean {
 
     // JIS X 0208: 2バイト
     if (isDoubleByteRange(byte)) {
-      if (
-        position + 1 >= buffer.length ||
-        !isDoubleByteRange(buffer[position + 1])
-      ) {
+      const next = buffer[position + 1];
+      if (next === undefined || !isDoubleByteRange(next)) {
         return false;
       }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -188,6 +188,10 @@ export function activate(context: vscode.ExtensionContext) {
 
             const selectedItem = selection[0];
 
+            if (selectedItem === undefined) {
+              return;
+            }
+
             if (selectedItem.label === "Enable convert") {
               vscode.commands.executeCommand("waveDashUnify.enableConvert");
             } else if (selectedItem.label === "Disable convert") {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "lib": ["ES2020"],
     "sourceMap": true,
     "rootDir": "src",
-    "strict": true, /* enable all strict type-checking options */
+    "strict": true /* enable all strict type-checking options */,
     /* Additional Checks */
     // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,10 +5,11 @@
     "lib": ["ES2020"],
     "sourceMap": true,
     "rootDir": "src",
-    "strict": true /* enable all strict type-checking options */
+    "strict": true, /* enable all strict type-checking options */
     /* Additional Checks */
     // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
     // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
     // "noUnusedParameters": true,  /* Report errors on unused parameters. */
+    "noUncheckedIndexedAccess": true /* Add undefined to a type when accessed using an index. */
   }
 }


### PR DESCRIPTION
## 何をしたか

`tsconfig.json`に`noUncheckedIndexedAccess`を有効化し、それによって型エラーになった箇所を修正した。

- `src/eucjp.ts`: `isEUCJPBuffer`のループ内で、SS2/SS3後続バイトの読み取りをローカル変数にホイストし、`undefined`を直接チェックする形にした。これに伴い、既存の`position + N >= buffer.length`という境界チェックは冗長になったため削除した(`undefined`チェックが同じ役割を果たす)。`isDoubleByteRange`/`isHalfwidthKatakanaByte`の引数型は`number`のまま変えていない(`number | undefined`に広げると、`noUncheckedIndexedAccess`を導入した目的である「境界チェック漏れの検出」が、このファイル自身で無効化されてしまうため)
- `src/extension.ts`: QuickPickの選択配列アクセスに`undefined`チェックを追加(`selection.length === 0`で早期returnしているため実質到達しない)

いずれも既存の実行時の分岐条件を変えるものではない。

## パフォーマンスへの影響(実測)

`isEUCJPBuffer`は保存処理のホットパス(VS Code 1.100.0未満での確定判定に使われる)のため、1MB/10MBのEUC-JPバッファでpure関数を直接ベンチマークし、変更前後を比較した(5回ウォームアップ後、1MBは200回・10MBは30回の平均)。

| サイズ | 変更前 | 変更後 | 差 |
| --- | --- | --- | --- |
| 1MB | 1.394 ms | 1.386 ms | -0.008 ms(誤差範囲) |
| 10MB | 13.912 ms | 13.889 ms | -0.023 ms(誤差範囲) |

有意な性能劣化は見られない。

## テスト

`npm run compile-tests` / `npm run compile` / `npm run lint` / `npm run format-check` / `npm run spellcheck`を確認。

`npm test`(Electron版)もNix経由のxvfb-run + NSS/NSPRでローカルにヘッドレス実行し、38件パスを確認した。CI(3 OSマトリクス)でもあわせて確認する。
