### PR TITLE
chore: npm run lintに--max-warnings 0を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "compile-tests": "tsc -p . --outDir out",
     "watch-tests": "tsc -p . -w --outDir out",
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
-    "lint": "eslint src",
+    "lint": "eslint src --max-warnings 0",
     "format": "prettier --write .",
     "format-check": "prettier --check .",
     "test": "node ./out/test/runTest.js",


### PR DESCRIPTION
## 何をしたか

`npm run lint`(`eslint src`)に`--max-warnings 0`を追加した。現状はwarning・errorともに0件のため、この変更自体で新たにCIが落ちることはない。

## なぜ

`eslint.config.js`では`@typescript-eslint/naming-convention` / `curly` / `eqeqeq` / `no-throw-literal`を`"warn"`で設定している。これまでは`npm run lint`がwarningでは失敗しなかったため、これらのルールに抵触するコードが紛れ込んでもCIは気付かずに通過してしまう状態だった。`--max-warnings 0`により、warningもCI・`pretest`(ひいては`npm test`)をブロックするようにする。

## 影響確認

- このブランチ上で`npm run lint`を実行し、exit 0(warning・error 0件)であることを確認した
- `pretest`スクリプトが`lint`を経由するため、`npm test`も同様にwarningでブロックされるようになる(意図通り)
- `vscode:prepublish`(`package`スクリプト、webpackのみ)はlint/testを経由しないため、リリース経路には影響しない

## テスト

`npm run lint`が0件のまま成功することを確認。他のnpm scriptには変更なし。
