### PR TITLE
chore: tsconfig.jsonのnoImplicitReturns/noFallthroughCasesInSwitch/noUnusedParametersを有効化する

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,9 +9,9 @@
     "esModuleInterop": true,
     "types": ["node", "mocha"],
     /* Additional Checks */
-    // "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
-    // "noUnusedParameters": true,  /* Report errors on unused parameters. */
+    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
+    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
+    "noUnusedParameters": true /* Report errors on unused parameters. */,
     "noImplicitOverride": true /* Ensure overriding members in derived classes are marked with an override modifier. */,
     "noUnusedLocals": true /* Report errors on unused locals. */,
     "noPropertyAccessFromIndexSignature": true /* Require undeclared properties from index signatures to use element accesses. */,


### PR DESCRIPTION
## 何をしたか

issue #672で提案されていた`tsconfig.json`の追加チェック3つを有効化した。

```jsonc
"noImplicitReturns": true,
"noFallthroughCasesInSwitch": true,
"noUnusedParameters": true,
```

コード変更はなく、`tsconfig.json`のみの変更(コメントアウトを解除しただけ)。

## 経緯

issue #672の「Doneの定義」は既に`[x]`でチェック済みになっていたが、`tsconfig.json`の該当3行は実際にはコメントアウトされたままで、有効化は未実装だった。issue #672とは別に進めていた「その他の厳密化」(#679〜#682)で兄弟フラグの`noUnusedLocals`は既に#679で有効化済みで、これにより`/* Additional Checks */`ブロックが完成する。

## 影響確認

issue #672記載の通り、有効化前に`src`配下全体に対して一時的に有効化し、エラー0件を確認した。

```
npx tsc -p . --noEmit --noImplicitReturns --noFallthroughCasesInSwitch --noUnusedParameters
```

さらに、コメントアウト解除が実際にパースされていることを`--showConfig`で確認し、`noUnusedParameters`については未使用引数を仕込んだ一時ファイルで実際にTS6133エラーになることも確認した(検証後に削除済み)。

## テスト

`npm run compile-tests` / `npm run compile` / `npm run lint` / `npm run format-check` / `npm run spellcheck`を確認。

`npm test`(Electron版)もNix経由のxvfb-run + NSS/NSPRでローカルにヘッドレス実行し、38件パスを確認した。CI(3 OSマトリクス)でもあわせて確認する。
