### PR TITLE
chore: tsconfig.jsonのハイジーンオプションを追加しeslintのecmaVersionをtsconfigと揃える

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,7 +16,7 @@ module.exports = [
     languageOptions: {
       parser: tsParser,
       parserOptions: {
-        ecmaVersion: 6,
+        ecmaVersion: "latest",
         sourceType: "module",
         projectService: true,
         tsconfigRootDir: __dirname,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,15 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "Node10",
     "target": "ES2020",
     "lib": ["ES2020"],
     "sourceMap": true,
     "rootDir": "src",
     "strict": true /* enable all strict type-checking options */,
     "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
     "types": ["node", "mocha"],
     /* Additional Checks */
     "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "rootDir": "src",
     "strict": true /* enable all strict type-checking options */,
     "esModuleInterop": true,
-    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "types": ["node", "mocha"],
     /* Additional Checks */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "moduleResolution": "Node10",
     "target": "ES2020",
     "lib": ["ES2020"],
     "sourceMap": true,


### PR DESCRIPTION
## 背景

`tsconfig.json` に以下のオプションが未指定だった。

- `moduleResolution`: `module: "commonjs"` 時の既定値は非推奨気味の `Node10` (旧`node`)
- `forceConsistentCasingInFileNames`: 未設定。macOS/Windows/Linuxの3OS CI matrix (`.github/workflows/test-and-publish.yml`) を回している以上、大文字小文字の取り違え事故を防ぐ効果がある

あわせて `eslint.config.js` の `parserOptions.ecmaVersion` が `6` (ES2015相当) 固定で `tsconfig.json` の `target` (`ES2020`) と数字上不整合だった。

## 変更内容

1. `tsconfig.json` の `compilerOptions` に `forceConsistentCasingInFileNames: true` を追加
2. `eslint.config.js` の `parserOptions.ecmaVersion` を `6` → `"latest"` に変更

**追記(2026-08-01①): `skipLibCheck: true` は追加後に撤回した。** レビューで、これが `.d.ts` 同士の整合性チェック(サードパーティ/自分自身の型定義ファイル間の矛盾検出)を無効化する変更であり、今回それを必要とする実際のエラーは発生していなかった点を指摘された。並行するIssue #685 では `@types/node` を16.x系に下げた際に実際に `.d.ts` 同士の衝突(`TS2320`)が発生し、その回避策として `skipLibCheck` が検討されたが、このリポジトリの直近の strict 系フラグ格上げ路線(#679, #680, #682, #683)とのトレードオフを理由に不採用となった。必要に迫られていない本PR側でだけ追加するのは一貫性を欠くため、`skipLibCheck` は外し、実質的な変更のない `moduleResolution` / `forceConsistentCasingInFileNames` の明文化と `eslint` の `ecmaVersion` 修正のみに絞った。

**追記(2026-08-01②): `moduleResolution: "Node10"` の明示指定も撤回した。** マージ前のCI再実行で `tsconfig.json(4,25): error TS5107: Option 'moduleResolution=node10' is deprecated and will stop functioning in TypeScript 7.0.` により `compile-tests` / `test-and-publish` / `devcontainer` が失敗することが判明した。原因は `package-lock.json` が固定する `typescript@6.0.3` がこのオプションの明示指定を非推奨のハードエラーにしたため。当初の「実質的な効果は変わらない」という検証はローカルのstaleな `node_modules`(実際には `typescript@5.9.3`相当が動いていた)に基づくもので、`npm ci` でlockfile通りに入れ直すと再現した。`moduleResolution` を明示せず未指定のままにしても `module: "commonjs"` 時の既定解決結果は変わらないため、当該行を削除する形で撤回し、`tsc` / `webpack` / `eslint` / `prettier` / `cspell` が全て通ることを再確認した。

## 検証: 各オプションの実質的な効果(誠実な申告)

- `forceConsistentCasingInFileNames: true`: TypeScript 4.7 以降、既定値がそもそも `true`。**今回の変更でも実質的な挙動は変わらない**。明示化のための追加。
- `moduleResolution`: 上記の通り撤回済み。既定値のまま(明示なし)。

このリポジトリのビルドは webpack + `ts-loader` 経由で `tsconfig.json` を読み込む構成になっている(`package.json` の `ts-loader` devDependency、`webpack.config.js` の `module.rules` で確認)。`npm run compile`(webpack)のビルド後の `extension.js` はバイト数・内容ともに変更前後で同一であることを確認済み。

`forceConsistentCasingInFileNames` による既存importパスの大文字小文字エラーも発生しなかった(元々既定でtrueだったため当然ではあるが、`tsc -p .` / `tsc -p . --outDir out` ともにエラー0件を確認)。

## 検証結果

すべてローカルで実行し成功(`npm ci` でlockfile通りにインストールした状態で再検証済み):

| コマンド | 結果 |
|---|---|
| `npm run compile-tests` (`tsc -p . --outDir out`, typescript 6.0.3) | 成功(エラー0件) |
| `npm run compile` (webpack) | 成功、`extension.js` 50.4 KiB(変更前と同一) |
| `npm run lint` (`eslint src --max-warnings 0`) | 成功(warning/error 0件) |
| `npm run format-check` (prettier) | 成功 |
| `npm run spellcheck` (cspell) | 成功、Issues found: 0 |
| `npm test` | CI(3 OSマトリクス)で確認 |

## 補足

- #687 (`tsconfig.json` の `lib` を ES2020→ES2021に変更、PR #690) が同じファイルの別箇所(`lib`)を変更している。今回の変更は `lib` 行を触っていないため意味的には独立だが、マージ順によっては軽微なリベースが必要になる可能性がある。

Closes #686
Refs #672