### PR TITLE
chore: dependabot.ymlのmocha ignore-ruleを削除しNode.jsバージョン前提の誤りを解消する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,12 +26,18 @@ updates:
       # engines.vscode, never on its own.
       - dependency-name: "@types/vscode"
 
-      # Mocha runs inside the VS Code extension host, so it is bound by the
-      # Node.js version of the OLDEST supported VS Code (1.66 ships Node 14),
-      # not by .nvmrc. Mocha 11 requires Node 18 or newer, so stay on 10.x until
-      # engines.vscode moves past the VS Code releases that bundle Node 14.
-      - dependency-name: "mocha"
-        update-types: ["version-update:semver-major"]
+      # NOTE: mocha is intentionally NOT ignored here (no ignore-rule below).
+      # Mocha runs inside the VS Code extension host, so its Node.js floor
+      # is the OLDEST supported VS Code, not .nvmrc: VS Code 1.66.0
+      # (engines.vscode's floor) bundles Electron 17.2.0, whose Node.js is
+      # v16.13.0 (Electron's DEPS file), not Node 14. Mocha 11 (currently in
+      # use; see #674) declares engines.node >=18.18, which 16.13.0 doesn't
+      # satisfy, but mocha is a devDependency excluded from dist/ and
+      # engines is an install-time warning, not a runtime check. Dependabot's
+      # "ignore" also suppresses security-update PRs, so ignoring majors here
+      # would cost more than an unenforced engines field is worth. Runtime
+      # backstop: `test-minimum-vscode-version` CI (1.66.0 / 1.100.0, 3
+      # OSes) must stay green; if a mocha bump turns it red, revisit this.
 
       # TypeScript 7 (the native/Go "tsgo" rewrite) is not yet supported by
       # the rest of the toolchain: @typescript-eslint's peer dependency caps


### PR DESCRIPTION
## 背景

`.github/dependabot.yml` のmocha用ignore-ruleのコメントには2つの問題があった。

1. **前提が事実誤り**: 「VS Code 1.66.0はNode 14を同梱する」と書かれていたが、実際はVS Code 1.66.0はElectron 17.2.0を同梱し、Electron 17.2.0のNode.jsは `v16.13.0`(Electronの`DEPS`ファイルの`node_version: 'v16.13.0'`で確認)。つまりこの拡張機能が保証すべき最も古いNode.jsはNode 14ではなくNode 16.13.0。
2. **実態との矛盾**: ignore-ruleが追加された同じcommit (`402a81d`, #661) の直後、#674(npm auditの高脅威度脆弱性修正)でmochaは`^10.8.2`→`^11.7.6`へ再度メジャーバンプされた。mocha 11.7.6の`engines.node`は`^18.18.0 || ^20.9.0 || >=21.1.0`で、Node 16.13.0を満たさない。ignore-ruleが想定していたポリシーと実態が矛盾したまま放置されていた。

Closes #684

## 決めた対応方針

Issueには (a) コメントをNode 16.13.0に訂正しignore-ruleを維持、(b) mocha 11.xを許容する方針に変更してコメント更新かrule削除、の2案が挙げられていた。

**mochaを10.x系に戻すことは選択肢にない**(#674の脆弱性修正が無効化される)ため、実質的な判断は「ignore-ruleを維持するか削除するか」に絞られる。以下の理由で **ignore-ruleを削除する(b寄り)** ことにした。

- GitHub Dependabotの`ignore`オプションは、通常のバージョン更新PRだけでなく**セキュリティアップデートPRも抑制する**(GitHub公式ドキュメントで確認)。このリポジトリは`vulnerability-alerts`が有効(`gh api repos/yutotnh/wave-dash-unify/vulnerability-alerts` → 204)であり、mocha配下の脆弱性は過去に何度か検知されている。ignore-ruleを維持すると、将来同様の脆弱性が出た際にDependabotが自動でPRを出せない状態が続く。
- mochaはdevDependencyで`dist/`には含まれない(webpackのentryは`src/extension.ts`のみ)ため、エンドユーザーへの影響はない。`engines`フィールドもinstall時の警告に留まり実行時には強制されない。
- 実行時の互換性は`test-minimum-vscode-version` CI job(`vscode-version: ["1.66.0", "1.100.0"]`、macOS/Linux/Windowsの3 OSマトリクス)が実際に検証しており、現状green。この仕組みは、ignore-ruleを残して他の3ルール(`@types/node`、`@types/vscode`、`typescript`)と横並びにするより、Dependabotが将来mocha 12以降を提案してきた際にCIが実行時の互換性を検証してくれる、という形の方が実態に即している。
- ignore-ruleを単に削除するだけだと「なぜmochaだけ他の3ルールのように守られていないのか」が将来の読み手に伝わらないため、rule自体は消しつつ、上記の理由(Node.jsバージョンの実態、devDependency扱い、Dependabotのignoreがセキュリティ更新も止める点、CI jobが実際のゲートである点)を要約したコメントを同じ場所に残した。

### 補足

- 本PRは#677(`@types/mocha`がmocha本体のメジャーバージョンに追従していない問題)には触れていない。`groups:`設定はないため、mochaと`@types/mocha`は今後も別々のPRとしてDependabotから提案される。
- ignore-rule削除後、`test-minimum-vscode-version`がmochaの更新によって赤くなった場合は、本PRの判断を見直すこと(コメント内にも明記)。

## 検証結果

YAML変更のみで本体コード(`src/`)には影響しないが、リポジトリ全体のチェックが壊れていないことを確認した。

- `npm run lint`: pass
- `npm run format-check`: pass
- `npm run spellcheck`: pass (Issues found: 0)
- YAML構文: `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` で正常にパース可能なことを確認

CHANGELOG.mdへの追記は行っていない(AGENTS.mdの方針: 依存関係更新・内部限定の変更は対象外)。ラベルも付与していない(chore/refactor系はAGENTS.mdの方針により無理に付けない)。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>