### PR TITLE
chore: tsconfig.jsonのlibをES2020からES2021に引き上げる

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "ES2020",
-    "lib": ["ES2020"],
+    "lib": ["ES2021"],
     "sourceMap": true,
     "rootDir": "src",
     "strict": true /* enable all strict type-checking options */,


### PR DESCRIPTION
## 背景

`tsconfig.json` の `target` と `lib` はどちらも `"ES2020"` だが意味が異なる。この拡張機能が実際に保証すべき最も古いNode.jsランタイムは Node.js 16.13.0 (`engines.vscode: "^1.66.0"` → VS Code 1.66.0が同梱するElectron 17.2.0 → Node.js v16.13.0)。Node 16.13.0のV8(9.4系)では以下がすでに使えるが、`lib: ["ES2020"]` のままだとtscがこれらの型定義を提供せずコンパイルエラーになる。

- `Object.hasOwn` (V8 9.3, Node 16.9+)
- `Array.prototype.at` (V8 9.2, Node 16.6+)
- `String.prototype.replaceAll` (V8 8.9, Node 15+)
- `Promise.any` (V8 8.9, Node 15+)
- `Error` の `cause` オプション (V8 9.3, Node 16.9+)

`target` を引き上げると `useDefineForClassFields` の既定値が変わる(ES2022以上で`true`になる)ため、クラスフィールドのemitセマンティクスに影響する別の意思決定になる。今回のスコープは `lib` のみとし、`target` は変更しない。

## 変更内容

`tsconfig.json` の `lib` を `["ES2020"]` から `["ES2021"]` に引き上げた(1行のみの変更)。

- `Promise.any`/`AggregateError`/`WeakRef`/`FinalizationRegistry`/`String.prototype.replaceAll`/論理代入演算子(`&&=` `||=` `??=`)/`ES2021.Intl`(`Intl.ListFormat`/`Intl.DateTimeFormat.formatRange`)はいずれもV8 9.0で確定済みで、Node 16.13.0(V8 9.4系)で安全に動作するため、最も保守的な引き上げとした。
- `target` は `ES2020` のまま変更していない。syntax(論理代入演算子など)はtscがdownlevelして出力するため、`target`が下でも`lib`だけの引き上げで出力に非対応構文が混ざることはない。
- `ES2022` の組み込み(`Array.prototype.at`/`Object.hasOwn`/`Error`の`cause`等)まで引き上げられるかは今回スコープ外とした。`test-minimum-vscode-version` (vscode-version: 1.66.0) のCIで動作確認できてから別途検討する。
- `src/` に `Intl.*` の利用は無く(`grep -rn "Intl\." src/` はヒットなし)、`ES2021.Intl` は現状inertな追加。

## 検証結果

以下をローカルで実行し、全て成功を確認した。

| コマンド | 結果 |
|---|---|
| `npm run compile-tests` | 成功 |
| `npm run compile` | 成功 (webpack) |
| `npm run lint` | 成功 |
| `npm run format-check` | 成功 |
| `npm run spellcheck` | 成功 (Issues found: 0) |

さらに `npm test` (Electron版) も、Nix経由のxvfb-run + NSS/NSPRのLD_LIBRARY_PATH注入でローカル実行できた。

- デフォルトバージョン(VS Code最新, 1.131.0相当): 38 passing
- `--vscode-version 1.66.0` (engines.vscodeの最小バージョン): ダウンロードに成功し、32 passing / 6 pending。pendingは`this.skip()`によるバージョンゲート(VS Code 1.100.0以降のEUC-JPエンコーディングAPI分岐に対応するテスト)であることをソースで確認済みで、想定通りの結果。

いずれも exit code 0。CIの3OSマトリクス、および `test-minimum-vscode-version` ジョブ(vscode-version: 1.66.0 / 1.100.0)でも確認予定。

Closes #687