### PR TITLE
chore: eslint-plugin-nでExtension Host向けコードにNode.jsビルトインAPIのバージョンガードを追加する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,8 +16,8 @@ updates:
       # version microsoft/vscode itself builds/develops with), NOT with the
       # Node.js runtime bundled by the oldest supported VS Code
       # (engines.vscode). Those are two different Node.js versions: the
-      # Extension Host that our own extension code (src/extension.ts,
-      # debounce.ts, eucjp.ts, src/test/suite/**) runs in is bound by
+      # Extension Host that our own extension code (everything under src/
+      # except src/test/runTest.ts) runs in is bound by
       # engines.vscode's bundled Node.js (currently v16.13.0, since
       # engines.vscode: "^1.66.0" bundles Electron 17.2.0, which bundles
       # Node.js v16.13.0 per Electron's DEPS file), while src/test/runTest.ts
@@ -33,9 +33,12 @@ updates:
       # want to trade away. Instead, Node 18+-only builtin misuse in the
       # Extension-Host-bound files is caught by eslint-plugin-n's
       # n/no-unsupported-features/* rules in eslint.config.js (scoped to
-      # >=16.13.0 for those files, >=18.3.0 for runTest.ts), so @types/node
+      # >=16.13.0 for src/**/*.ts, >=18.3.0 for runTest.ts), so @types/node
       # can keep tracking .nvmrc without drift risk to the actual runtime
-      # floor. Allow patch/minor updates within the .nvmrc major, but ignore
+      # floor. That guard covers global references and module members only,
+      # not prototype methods (Array#at etc.), which tsconfig.json's
+      # "lib": ["ES2020"] catches instead.
+      # Allow patch/minor updates within the .nvmrc major, but ignore
       # major bumps so this ignore-rule isn't silently made stale.
       # Bump this rule (and the eslint-plugin-n version ranges) when .nvmrc
       # moves to a new Node.js major, and revisit the eslint-plugin-n version

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,35 @@ updates:
     reviewers:
       - "yutotnh"
     ignore:
-      # Keep @types/node aligned with VS Code's Node.js major (see .nvmrc).
-      # Allow patch/minor updates within the major, but ignore major bumps so
-      # the type definitions don't drift ahead of the runtime Node.js version.
-      # Bump this rule when .nvmrc moves to a new Node.js major.
+      # @types/node is intentionally kept aligned with .nvmrc (the Node.js
+      # version microsoft/vscode itself builds/develops with), NOT with the
+      # Node.js runtime bundled by the oldest supported VS Code
+      # (engines.vscode). Those are two different Node.js versions: the
+      # Extension Host that our own extension code (src/extension.ts,
+      # debounce.ts, eucjp.ts, src/test/suite/**) runs in is bound by
+      # engines.vscode's bundled Node.js (currently v16.13.0, since
+      # engines.vscode: "^1.66.0" bundles Electron 17.2.0, which bundles
+      # Node.js v16.13.0 per Electron's DEPS file), while src/test/runTest.ts
+      # (the dev/CI-machine test launcher, run via
+      # `node ./out/test/runTest.js`, never inside the Extension Host) runs
+      # under .nvmrc's Node.js.
+      #
+      # We previously tried pinning @types/node itself to the Extension
+      # Host's Node.js floor (16.x), but that doesn't work: it breaks tsc for
+      # runTest.ts (which legitimately uses Node 18.3+'s node:util.parseArgs)
+      # and @types/node@16.x's own .d.ts files conflict with our pinned
+      # TypeScript version, fixable only via skipLibCheck, which we don't
+      # want to trade away. Instead, Node 18+-only builtin misuse in the
+      # Extension-Host-bound files is caught by eslint-plugin-n's
+      # n/no-unsupported-features/* rules in eslint.config.js (scoped to
+      # >=16.13.0 for those files, >=18.3.0 for runTest.ts), so @types/node
+      # can keep tracking .nvmrc without drift risk to the actual runtime
+      # floor. Allow patch/minor updates within the .nvmrc major, but ignore
+      # major bumps so this ignore-rule isn't silently made stale.
+      # Bump this rule (and the eslint-plugin-n version ranges) when .nvmrc
+      # moves to a new Node.js major, and revisit the eslint-plugin-n version
+      # floors if engines.vscode moves to a newer minimum VS Code version
+      # that bundles a newer Node.js major.
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,8 @@ wave-dash-unifyは単一パッケージのTypeScript製VS Code拡張機能。本
 - CIは`actions/setup-node`の`node-version-file: ./.nvmrc`で自動追従する(ワークフロー変更は不要)
 - `.devcontainer/`もビルド時に`.nvmrc`を読んでnvmでインストールする(Dockerfileへの直書きはしない)
 - 上げる場合は`.nvmrc`を書き換え、`@types/node`のメジャーバージョンも追従させ、`.github/dependabot.yml`の無視ルールも更新する
-- 注意: `@types/node`(型定義)が追従する`.nvmrc`と、Extension Host内で実際に動くコード(`src/extension.ts`/`debounce.ts`/`eucjp.ts`/`src/test/suite/**`)の実行時Node.jsバージョン(`engines.vscode`が同梱するNode.js、現状v16.13.0)は別物。両者の乖離により`tsc`がNode 18+専用APIの誤用を見逃さないよう、`eslint.config.js`の`eslint-plugin-n`(`n/no-unsupported-features/*`)がExtension Host側コードを実行時floorでガードしている(詳細は`.github/dependabot.yml`の`@types/node`コメント参照)
+- 注意: `@types/node`(型定義)が追従する`.nvmrc`と、Extension Host内で実際に動くコードの実行時Node.jsバージョン(`engines.vscode`が同梱するNode.js、現状v16.13.0)は別物。両者の乖離により`tsc`がNode 18+専用APIの誤用を見逃さないよう、`eslint.config.js`の`eslint-plugin-n`(`n/no-unsupported-features/*`)が`src/**/*.ts`を実行時floorでガードしている(`src/test/runTest.ts`だけはdev/CI機で動くため`>=18.3.0`で上書き。詳細は`.github/dependabot.yml`の`@types/node`コメント参照)
+  - このガードが見るのは**グローバル参照とモジュールメンバのみ**。プロトタイプメソッド(`Array#at`、`String#replaceAll`など)は対象外で、そちらは`tsconfig.json`の`"lib": ["ES2020"]`が捕捉する。ルールのデータ自体も網羅的ではない(`localStorage`/`EventSource`/`Array.fromAsync`等はeslint-plugin-n 18.xに項目がない)ため、安全網であって保証ではない
 
 ## パフォーマンスに関する変更
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ wave-dash-unifyは単一パッケージのTypeScript製VS Code拡張機能。本
 - CIは`actions/setup-node`の`node-version-file: ./.nvmrc`で自動追従する(ワークフロー変更は不要)
 - `.devcontainer/`もビルド時に`.nvmrc`を読んでnvmでインストールする(Dockerfileへの直書きはしない)
 - 上げる場合は`.nvmrc`を書き換え、`@types/node`のメジャーバージョンも追従させ、`.github/dependabot.yml`の無視ルールも更新する
+- 注意: `@types/node`(型定義)が追従する`.nvmrc`と、Extension Host内で実際に動くコード(`src/extension.ts`/`debounce.ts`/`eucjp.ts`/`src/test/suite/**`)の実行時Node.jsバージョン(`engines.vscode`が同梱するNode.js、現状v16.13.0)は別物。両者の乖離により`tsc`がNode 18+専用APIの誤用を見逃さないよう、`eslint.config.js`の`eslint-plugin-n`(`n/no-unsupported-features/*`)がExtension Host側コードを実行時floorでガードしている(詳細は`.github/dependabot.yml`の`@types/node`コメント参照)
 
 ## パフォーマンスに関する変更
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,16 @@ const tsParser = require("@typescript-eslint/parser");
 const prettierConfig = require("eslint-config-prettier");
 const nPlugin = require("eslint-plugin-n");
 
+// n/no-unsupported-features/* only flags globals that ESLint's scope
+// analysis can see as declared globals (checked via eslint-utils'
+// ReferenceTracker against languageOptions.globals). Without this,
+// @typescript-eslint/parser resolves Node/Web globals (structuredClone,
+// fetch, etc.) through @types/node's ambient declarations instead, so the
+// rule silently never flags them. Reuse the plugin's own recommended
+// globals list rather than hand-picking a subset.
+const nodeBuiltinGlobals =
+  nPlugin.configs["flat/recommended"].languageOptions.globals;
+
 module.exports = [
   {
     ignores: ["out/**", "dist/**", "**/*.d.ts"],
@@ -47,6 +57,9 @@ module.exports = [
       "src/test/suite/**/*.ts",
     ],
     plugins: { n: nPlugin },
+    languageOptions: {
+      globals: nodeBuiltinGlobals,
+    },
     rules: {
       "n/no-unsupported-features/node-builtins": [
         "error",
@@ -72,6 +85,9 @@ module.exports = [
     // experimental-only Node.
     files: ["src/test/runTest.ts"],
     plugins: { n: nPlugin },
+    languageOptions: {
+      globals: nodeBuiltinGlobals,
+    },
     rules: {
       "n/no-unsupported-features/node-builtins": [
         "error",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,15 +47,12 @@ module.exports = [
     // (engines.vscode), not by .nvmrc. engines.vscode: "^1.66.0" -> VS Code
     // 1.66.0 bundles Electron 17.2.0 -> Electron 17.2.0 bundles Node.js
     // v16.13.0 (see Electron's DEPS file). Guard against accidentally using
-    // Node 18+-only builtins (structuredClone, fs.cp, Array#at, etc.) that
-    // tsc alone would not catch, since @types/node intentionally tracks
-    // .nvmrc (see .github/dependabot.yml) rather than this runtime floor.
-    files: [
-      "src/extension.ts",
-      "src/debounce.ts",
-      "src/eucjp.ts",
-      "src/test/suite/**/*.ts",
-    ],
+    // Node 18+-only builtins (structuredClone, fs.cp, etc.) that tsc alone
+    // would not catch, since @types/node intentionally tracks .nvmrc (see
+    // .github/dependabot.yml) rather than this runtime floor. Matches all of
+    // src/ (not an explicit file list) so newly added files are covered by
+    // default; src/test/runTest.ts overrides this below with its own floor.
+    files: ["src/**/*.ts"],
     plugins: { n: nPlugin },
     languageOptions: {
       globals: nodeBuiltinGlobals,
@@ -92,6 +89,13 @@ module.exports = [
       "n/no-unsupported-features/node-builtins": [
         "error",
         { version: ">=18.3.0", allowExperimental: true },
+      ],
+      // Overrides the broader src/**/*.ts block's es-builtins floor above
+      // (>=16.13.0); without this, this file would inherit the stricter
+      // Extension Host floor instead of its own >=18.3.0 dev/CI-machine one.
+      "n/no-unsupported-features/es-builtins": [
+        "error",
+        { version: ">=18.3.0" },
       ],
     },
   },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ const js = require("@eslint/js");
 const tsPlugin = require("@typescript-eslint/eslint-plugin");
 const tsParser = require("@typescript-eslint/parser");
 const prettierConfig = require("eslint-config-prettier");
+const nPlugin = require("eslint-plugin-n");
 
 module.exports = [
   {
@@ -28,6 +29,54 @@ module.exports = [
       eqeqeq: "warn",
       "no-throw-literal": "warn",
       semi: "off",
+    },
+  },
+  {
+    // Code that runs inside the VS Code Extension Host is bound by the
+    // Node.js version bundled by the OLDEST supported VS Code
+    // (engines.vscode), not by .nvmrc. engines.vscode: "^1.66.0" -> VS Code
+    // 1.66.0 bundles Electron 17.2.0 -> Electron 17.2.0 bundles Node.js
+    // v16.13.0 (see Electron's DEPS file). Guard against accidentally using
+    // Node 18+-only builtins (structuredClone, fs.cp, Array#at, etc.) that
+    // tsc alone would not catch, since @types/node intentionally tracks
+    // .nvmrc (see .github/dependabot.yml) rather than this runtime floor.
+    files: [
+      "src/extension.ts",
+      "src/debounce.ts",
+      "src/eucjp.ts",
+      "src/test/suite/**/*.ts",
+    ],
+    plugins: { n: nPlugin },
+    rules: {
+      "n/no-unsupported-features/node-builtins": [
+        "error",
+        { version: ">=16.13.0" },
+      ],
+      "n/no-unsupported-features/es-builtins": [
+        "error",
+        { version: ">=16.13.0" },
+      ],
+    },
+  },
+  {
+    // src/test/runTest.ts is the dev/CI-machine test launcher (run via
+    // `node ./out/test/runTest.js`, never inside the Extension Host), so it
+    // is bound by .nvmrc's Node.js version (currently 24.x), not by the
+    // Extension Host floor above. The floor is set to the version that
+    // introduced util.parseArgs (18.3.0) rather than .nvmrc's current major,
+    // since that is the actual minimum this file's code requires.
+    // allowExperimental is needed because parseArgs was flagged
+    // "experimental" until Node 20.0.0; that stability label doesn't matter
+    // here since dev/CI machines always run .nvmrc's Node (currently far
+    // newer than 20), so it never actually executes in an
+    // experimental-only Node.
+    files: ["src/test/runTest.ts"],
+    plugins: { n: nPlugin },
+    rules: {
+      "n/no-unsupported-features/node-builtins": [
+        "error",
+        { version: ">=18.3.0", allowExperimental: true },
+      ],
     },
   },
   prettierConfig,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,11 +47,19 @@ module.exports = [
     // (engines.vscode), not by .nvmrc. engines.vscode: "^1.66.0" -> VS Code
     // 1.66.0 bundles Electron 17.2.0 -> Electron 17.2.0 bundles Node.js
     // v16.13.0 (see Electron's DEPS file). Guard against accidentally using
-    // Node 18+-only builtins (structuredClone, fs.cp, etc.) that tsc alone
-    // would not catch, since @types/node intentionally tracks .nvmrc (see
-    // .github/dependabot.yml) rather than this runtime floor. Matches all of
-    // src/ (not an explicit file list) so newly added files are covered by
-    // default; src/test/runTest.ts overrides this below with its own floor.
+    // Node 18+-only builtins (structuredClone, fetch, fs.cp, etc.) that tsc
+    // alone would not catch, since @types/node intentionally tracks .nvmrc
+    // (see .github/dependabot.yml) rather than this runtime floor. Matches
+    // all of src/ (not an explicit file list) so newly added files are
+    // covered by default; src/test/runTest.ts overrides this below with its
+    // own floor.
+    //
+    // Scope caveat: these rules only inspect global references and module
+    // members. Prototype methods (Array#at, String#replaceAll, ...) are NOT
+    // covered; those are caught by tsconfig.json's "lib": ["ES2020"]
+    // instead. The rules' data is not exhaustive either (localStorage,
+    // EventSource and Array.fromAsync have no entry in eslint-plugin-n
+    // 18.x), so treat this as a safety net rather than a proof.
     files: ["src/**/*.ts"],
     plugins: { n: nPlugin },
     languageOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "cspell": "^10.0.1",
         "eslint": "^10.8.0",
         "eslint-config-prettier": "^10.1.5",
+        "eslint-plugin-n": "^18.2.2",
         "mocha": "^11.7.6",
         "ovsx": "^1.0.2",
         "prettier": "^3.5.3",
@@ -4071,6 +4072,22 @@
         }
       }
     },
+    "node_modules/eslint-compat-utils": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
+      "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
     "node_modules/eslint-config-prettier": {
       "version": "10.1.8",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
@@ -4085,6 +4102,74 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-es-x": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
+      "integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/ota-meshi",
+        "https://opencollective.com/eslint"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.11.0",
+        "eslint-compat-utils": "^0.5.1"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-n": {
+      "version": "18.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-18.2.2.tgz",
+      "integrity": "sha512-gOO0lIqwEjZ750kv9/SptCWArUoAZXJoBr0vYWTO2dCBxctHUXlBIigiC8xuxxr/NKqgIT6Ehz1xRcilj8a5cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.5.0",
+        "enhanced-resolve": "^5.17.1",
+        "eslint-plugin-es-x": "^7.8.0",
+        "get-tsconfig": "^4.8.1",
+        "globals": "^15.11.0",
+        "globrex": "^0.1.2",
+        "ignore": "^5.3.2",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.57.1",
+        "ts-declaration-location": "^1.0.6",
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-declaration-location": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/eslint-scope": {
@@ -4618,6 +4703,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
@@ -4673,6 +4771,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globalthis": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
@@ -4710,6 +4821,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -7047,6 +7165,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/restore-cursor": {

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "cspell": "^10.0.1",
     "eslint": "^10.8.0",
     "eslint-config-prettier": "^10.1.5",
+    "eslint-plugin-n": "^18.2.2",
     "mocha": "^11.7.6",
     "ovsx": "^1.0.2",
     "prettier": "^3.5.3",


### PR DESCRIPTION
## 背景

#685 が指摘した通り、`@types/node: "24.x"` は `.nvmrc`(microsoft/vscode自身のビルド/開発機のNode.jsバージョン、現状24.18.0)に追従する意図だが、この拡張機能が実際にサポートする最も古いVS Code(`engines.vscode: "^1.66.0"`)が同梱するNode.jsは v16.13.0(VS Code 1.66.0 → Electron 17.2.0 → Node.js v16.13.0、Electronの`DEPS`ファイルで確認)であり、型定義が実行時floorより8メジャー先行していた。これにより `structuredClone` / `fs.cp` などNode 18+専用APIをtscがコンパイルエラーなく許してしまうガードレール不在の状態だった(なお `Array#at` はプロトタイプメソッドで、`eslint-plugin-n` の対象範囲外。これは `tsconfig.json` の `lib` 設定側でガードされるもので、本PRの守備範囲ではない。誤解を招く記載だったため訂正する)。

## 方針転換の経緯(正直に書きます)

issue #685 は当初「(b) `@types/node` を実行時floor(Node 16系)にpinする」を採用する前提だったが、実装を進めたところ2つの理由でこの方式は断念した。

1. **実行時floorはsrc/内で単一ではない。** `src/test/runTest.ts` は `node ./out/test/runTest.js` としてdev/CI機のNode(`.nvmrc`、現状24.x)でのみ実行され、VS CodeのExtension Host内では動かない。このファイルは意図的に `node:util` の `parseArgs`(Node 18.3+)を使っている(過去のyargsからの置き換え)。一方 `src/extension.ts` / `debounce.ts` / `eucjp.ts` / `src/test/suite/**` はExtension Host内(floor = Node 16.13.0)で動く。1つの `@types/node` バージョンではこの2つの異なるfloorを両立して表現できず、`@types/node@16.x` にpinすると `runTest.ts` の `parseArgs` がtscエラーになる。
2. **`@types/node@16.x` 自体がTypeScript 6.0.3と衝突する。** `@types/node@16.18.11`〜`16.18.126`のいずれでも、`https.d.ts` の `AgentOptions` が `AgentOptions` と `ConnectionOptions` を同時にextendsして `port` プロパティの型が一致せず `TS2320` エラーになる(このリポジトリ自身のコードとは無関係な `.d.ts` 間の衝突)。唯一の回避策は `skipLibCheck: true` だが、これは直近のPR(#679/#680/#682/#683の型チェック厳格化の流れ、および別PRで`skipLibCheck`相当の緩和策をユーザーの要望により撤回した経緯)と方向性が逆行するため採用しなかった。

そこで **eslint-plugin-n** の `n/no-unsupported-features/*` ルールで、tscではなくESLint側にファイル単位のNode.jsビルトインAPIバージョンガードを実装する方式(b-lint)に切り替えた。`@types/node` は引き続き `.nvmrc` に追従させたまま(`24.x`)、実行時floorとの乖離自体はeslintのガードで別途担保する。

## 変更内容

- **`eslint.config.js`**: `eslint-plugin-n` を追加し、ファイルグロブ単位で `n/no-unsupported-features/node-builtins` と `n/no-unsupported-features/es-builtins` を設定
  - `src/extension.ts`, `src/debounce.ts`, `src/eucjp.ts`, `src/test/suite/**/*.ts`(Extension Host内で動く) → `version: ">=16.13.0"`
  - `src/test/runTest.ts`(dev/CI機のNodeで動く) → `version: ">=18.3.0"`(`parseArgs` はNode 20.0.0まで experimental 扱いのため `allowExperimental: true` も指定)
- **`package.json` / `package-lock.json`**: `eslint-plugin-n@^18.2.2` を devDependencies に追加(peerDependencies: `eslint >=8.57.1`、`typescript >=5.0.0` — 本リポジトリの `eslint@^10.8.0` / `typescript@^6.0.3` と両立を確認済み)。`@types/node` は `24.x` のまま変更なし
- **`.github/dependabot.yml`**: `@types/node` の ignore ルールのコメントを書き換え。「`.nvmrc` に意図的に追従させている」「Extension Host側の実行時floorとの乖離はeslint-plugin-nでガードしている」という現状の設計を明記
- **`AGENTS.md`**: 「Node.jsバージョン」節に、`.nvmrc`(型定義・ビルド機)とExtension Hostの実行時floorが別物であること、両者の乖離をeslint-plugin-nでガードしていることの補足を追加

## 検証結果

- `npm install`: 依存関係解決・peer dependency警告なし
- `npx tsc -p . --outDir out`(`compile-tests`)/ `npm run compile`(webpack): エラーなし
- `npm run lint`(`eslint src --max-warnings 0`): 0件でパス(既存コードはNode 18+専用APIを使っていないことを確認済み)
- `npm run format-check`: パス
- `npm run spellcheck`: パス(Files checked: 52, Issues found: 0)
- `npm test`(Nix経由のxvfb + NSS/NSPRでヘッドレス実行):
  - デフォルト(VS Code 1.131.0、既存キャッシュ使用): **38 passing**
  - `--vscode-version 1.66.0`(サポート対象最古のVS Code。`update.code.visualstudio.com`へのダウンロードが必要で、今回のサンドボックスでは到達できた): **32 passing, 6 pending**(pendingはVS Code 1.100.0以降のAPI有無で切り替わるテストが1.66.0では正しくskipされたもの、#661のfeatureに対応)
  - いずれもexit code 0

Closes #685

## 追記(2026-08-02): レビューで発覚した不具合を修正

独立レビューで、本PRが謳う「`structuredClone`/`fetch`などのグローバル系Node.jsビルトインAPIも検出できる」という主張が誤りだったことが判明した。

**再現**: `src/debounce.ts`に一時的に`structuredClone({a:1})`や`typeof fetch`を追加して`npx eslint`を実行したところ、`fs.cp`(モジュール経由API)は正しく検出される一方、`structuredClone`/`fetch`(グローバルAPI)はエラーにならず素通りしていた。

**原因**: `n/no-unsupported-features/*`は内部で`eslint-utils`の`ReferenceTracker`を使い、`languageOptions.globals`に宣言されたグローバル変数の参照だけを追跡する。本PRの当初の設定には`languageOptions.globals`の指定がなく、`@typescript-eslint/parser`は`structuredClone`等を`@types/node`のグローバル宣言経由で解決してしまうため、ESLint側のスコープ解析上は「追跡対象のグローバル参照」として認識されず、ルールが黙って何も検出しない状態になっていた。

**修正**: `eslint-plugin-n`自身の`flat/recommended`設定が`languageOptions.globals`としてNode/Web環境のグローバル一覧(`structuredClone`/`fetch`/`AbortController`等を含む)を持っていたため、これをそのまま両方のカスタムブロックの`languageOptions.globals`に設定した。修正後、同じ再現手順で`structuredClone`/`fetch`とも正しく`n/no-unsupported-features/node-builtins`のエラーとして検出されることを確認し、既存コードに対する`npm run lint`が引き続き0件でパスすることも確認した。

これでissue #685が当初問題視していたグローバル系API(`structuredClone`, `fetch`, `AbortController`等)も含めて、意図した通りガードされるようになった。

## 追記(2026-08-02 その2): 独立サブエージェントによる敵対的レビューで2件追加修正

実装に関与していない別のサブエージェント(Opus)に、直前の修正コミットを含むPR全体を再度独立レビューしてもらった。実際に`structuredClone`/`fetch`/`AbortSignal.timeout`/`Object.groupBy`等を検出できることを再現確認した上で、以下2件の指摘があり、両方対応した。

1. **[中] Extension Host向けブロックの`files`が4ファイルの直書きで、新規追加ファイルが無防備だった。** `npx eslint --print-config <新規ファイル>`でn/ルールが1つも解決されないことを確認。`files`を`src/**/*.ts`に広げ、新規ファイルもデフォルトでガード対象に入るようにした。
2. **[低] `src/test/runTest.ts`向けブロックに`es-builtins`の指定がなく、`Object.groupBy`等がそこだけ素通りしていた。** 1の変更で暗黙にExtension Host側の`es-builtins`(`>=16.13.0`)を継承するようになるが、それは`runTest.ts`自身の実際のfloor(`>=18.3.0`)より厳しすぎるため、明示的に`es-builtins: ["error", {version: ">=18.3.0"}]`で上書きする設定を追加した。

さらに、「本PRが`Array#at`をガードする」という当初の記載が不正確だった点も訂正した(`eslint-plugin-n`はグローバル変数とモジュールメンバのみを対象とし、プロトタイプメソッドは対象外。`Array#at`は`tsconfig.json`の`lib`設定側で防がれているもので、本PRの成果ではない)。

**網羅性の限界**: `localStorage`/`sessionStorage`/`EventSource`/`URLPattern`/`Array.fromAsync`等は、`eslint-plugin-n@18.2.2`のルールデータ自体にエントリがないため検出されない(設定ミスではなく、依存パッケージの網羅範囲の限界)。「完全に網羅的」ではない旨をここに明記しておく。

`--print-config`での設定解決結果の確認、`npm run lint`/`compile-tests`/`compile`/`format-check`/`spellcheck`が全て通ることを再確認済み。
