### PR TITLE
docs: dependabot.ymlの@types/node固定断念理由を実測ベースで明確化する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,12 +26,26 @@ updates:
       # under .nvmrc's Node.js.
       #
       # We previously tried pinning @types/node itself to the Extension
-      # Host's Node.js floor (16.x), but that doesn't work: it breaks tsc for
-      # runTest.ts (which legitimately uses Node 18.3+'s node:util.parseArgs)
-      # and @types/node@16.x's own .d.ts files conflict with our pinned
-      # TypeScript version, fixable only via skipLibCheck, which we don't
-      # want to trade away. Instead, Node 18+-only builtin misuse in the
-      # Extension-Host-bound files is caught by eslint-plugin-n's
+      # Host's Node.js floor (16.x), but that hits two INDEPENDENT blockers,
+      # either one fatal on its own (confirmed by actually installing
+      # @types/node@16.18.126 and running tsc, not just reasoning about it):
+      #   1. It breaks tsc for runTest.ts, which legitimately uses Node
+      #      18.3+'s node:util.parseArgs -> TS2305 (parseArgs doesn't exist
+      #      on this @types/node's node:util). Rewriting runTest.ts to avoid
+      #      parseArgs removes only this error.
+      #   2. @types/node@16.x's own .d.ts has an internal conflict with our
+      #      pinned TypeScript version: node_modules/@types/node/https.d.ts
+      #      fails with TS2320 ("Interface 'AgentOptions' cannot
+      #      simultaneously extend types 'AgentOptions' and
+      #      'ConnectionOptions'"), fixable only via skipLibCheck, which we
+      #      don't want to trade away. This is unrelated to our own code and
+      #      still fails even after fixing (1). Downgrading typescript to
+      #      dodge it (tried 5.3.3) just trades TS2320 for a different
+      #      conflict in @vscode/test-electron's own .d.ts (TS2315, "Type
+      #      'Buffer' is not generic"), since that dependency's types also
+      #      assume a newer @types/node.
+      # Instead, Node 18+-only builtin misuse in the Extension-Host-bound
+      # files is caught by eslint-plugin-n's
       # n/no-unsupported-features/* rules in eslint.config.js (scoped to
       # >=16.13.0 for src/**/*.ts, >=18.3.0 for runTest.ts), so @types/node
       # can keep tracking .nvmrc without drift risk to the actual runtime


### PR DESCRIPTION
## 背景

#691 で `.github/dependabot.yml` の `@types/node` 無視ルールに追加したコメントは、「`parseArgs` が壊れる」ことと「`.d.ts` が衝突する」ことを並記していたが、これが2つの独立した理由であることが伝わりにくく、「`parseArgs` を使わない実装に変えれば `@types/node` を16.x系に固定できるのでは」という指摘を受けた。

## 検証(推測ではなく実機確認)

リポジトリ全体を一時ディレクトリにコピーし、`@types/node` を `16.18.126`(16.x系最新パッチ)に差し替えて実際に `tsc` を実行した。

1. `typescript@6.0.3`(現行ピン)のまま実行 → 以下の**2件が独立して**発生:
   - `src/test/runTest.ts` の `TS2305`(`parseArgs` が存在しない)
   - `node_modules/@types/node/https.d.ts` の `TS2320`(`AgentOptions` が `AgentOptions` と `ConnectionOptions` を同時extendsして矛盾。`@types/node@16.x` 自身の宣言ファイル内部の問題で、こちらのコードとは無関係)
2. `runTest.ts` から `parseArgs` を削除(`process.argv` を手動パースする実装に置換)して再実行 → `TS2305` は消えるが **`TS2320` はそのまま残る**
3. 念のため `typescript@5.3.3`(Node 16世代相当の古いTS)に下げて再試行 → `TS2320` は消えるが、代わりに依存パッケージ `@vscode/test-electron` 自身の型定義で別の `TS2315`(`Buffer` が generic でない)が発生。こちらも自分たちのコードでは制御できない外部依存の型不整合

## 変更内容

`@types/node` 無視ルールのコメントを、上記2つを**それぞれ単独でも致命的な独立した理由**として書き分け、実測した具体的なエラー内容を添えた。方針(eslint-plugin-nガードで代替する)自体の変更は無し。

## 検証結果

| コマンド | 結果 |
|---|---|
| `npm run format-check` | 成功 |
| `npm run spellcheck` | 成功、Issues found: 0 |

コメントのみの変更でユーザー向け挙動変更を伴わないため、CHANGELOG.mdへの追記は対象外。