### PR TITLE
chore: package.jsonのlicenseフィールドをMITに変更する

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/yutotnh/wave-dash-unify.git"
   },
   "homepage": "https://github.com/yutotnh/wave-dash-unify",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "activationEvents": [
     "onStartupFinished"
   ],


### PR DESCRIPTION
## Summary

- \`package.json\`の\`license\`フィールドを\`"SEE LICENSE IN LICENSE"\`から\`"MIT"\`に変更
- \`LICENSE\`ファイルの中身は標準のMITライセンス条文そのままであり、独自条項がないためSPDX識別子\`"MIT"\`を使う方が適切
- npmのパッケージページやライセンスチェッカーなどのツールがSPDX識別子として機械的に認識できるようになる

Closes #696

## Test plan

- [x] \`npm run lint\`
- [x] \`npm run format-check\`
- [x] \`npm run spellcheck\`
- [x] \`npm test\`はサンドボックス環境でElectron版がローカル実行できないためCI(3 OSマトリクス)で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PZM1Loei47JjCGPqhWN96q