### PR TITLE
fix: publish時のREADME相対リンクをリリースタグ基準に固定する

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,8 @@
   "scripts": {
     "vscode:package": "vsce package",
     "vscode:prepublish": "npm run package",
-    "vscode:publish": "vsce publish",
-    "vscode:publish-ovsx": "ovsx publish",
+    "vscode:publish": "vsce publish --githubBranch v$npm_package_version",
+    "vscode:publish-ovsx": "ovsx publish --baseContentUrl https://github.com/yutotnh/wave-dash-unify/blob/v$npm_package_version --baseImagesUrl https://github.com/yutotnh/wave-dash-unify/raw/v$npm_package_version",
     "compile": "webpack",
     "watch": "webpack --watch",
     "package": "webpack --mode production --devtool hidden-source-map",


### PR DESCRIPTION
## Summary
- `vsce`/`ovsx`はpublish時にREADME.mdの相対リンク・画像パスを絶対URLへ書き換えるが、明示指定がないとGitHubの`HEAD`(デフォルトブランチ=`main`)を参照先にする
- publishはリリースタグ(`v<version>`)push時のみ実行され、タグ名は`package.json`の`version`と一致する運用なので、`vscode:publish`/`vscode:publish-ovsx`に公開時点のタグを明示的に渡し、Marketplace上のREADMEリンクが`main`の変化に伴ってズレていく問題を解消する
  - `vsce publish`: `--githubBranch v$npm_package_version`
  - `ovsx publish`: `--baseContentUrl`/`--baseImagesUrl`で同等のURLを直接指定(ovsxに`--githubBranch`相当のオプションはないため)
- 対象スクリプトはCIの`test-and-publish.yml`で`ubuntu-latest`かつタグpush時のみ実行されるため、`$npm_package_version`のPOSIXシェル展開に依存しても問題ない

## Test plan
- [x] `npx vsce package -o <tmp> --githubBranch v0.4.1`でパッケージングし、生成物内`extension/readme.md`の相対リンク(`doc/design.md`、`CHANGELOG.md`)が`https://github.com/yutotnh/wave-dash-unify/blob/v0.4.1/...`に書き換わることを確認
- [x] `npm run format-check`
- [x] `npm run lint`
- [ ] CI(3 OSマトリクス)でのテスト結果を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHWuqkG5B2T6FYEan3hb3E