### PR TITLE
chore: doc/**と.dockerignoreをVSIXパッケージから除外する

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -5,6 +5,8 @@
 out/**
 node_modules/**
 src/**
+doc/**
+!doc/icon.png
 .gitignore
 .npmrc
 webpack.config.js
@@ -18,3 +20,4 @@ webpack.config.js
 .claude/**
 AGENTS.md
 CLAUDE.md
+.dockerignore


### PR DESCRIPTION
## Summary
- `doc/design.md`は拡張機能の実行時には使われず、README.mdから相対リンクで参照されるだけ。その相対リンクは`vsce`/`ovsx`のpublish時にGitHub上の絶対URL(#698でリリースタグ基準に固定)へ自動的に書き換えられるため、VSIX内に実体を同梱する必要はない
- `doc/icon.png`は`package.json`の`icon`フィールドが参照するため、`!doc/icon.png`で除外対象から除外する
- `.dockerignore`は`.gitignore`/`.npmrc`/`.nvmrc`と同様、エンドユーザーに不要な開発用ファイルなので既存パターンに揃えて除外する(過去の`.claude/**`除外と同じ理由、`AGENTS.md`参照)

## Test plan
- [x] `npx vsce ls`で`doc/design.md`・`.dockerignore`がVSIXの同梱ファイル一覧から消え、`doc/icon.png`は残っていることを確認
- [x] `npm run format-check`
- [x] `npm run lint`
- [x] CI(3 OSマトリクス)でのテスト結果を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EHWuqkG5B2T6FYEan3hb3E