### PR TITLE
chore: バージョンを0.5.0に更新し、CHANGELOGを更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ or each release's GitHub Releases page for those.
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-08-04
+
 ### Added
 
 - Open VSX Registryでの配布に対応しました。VSCodiumなど、Open VSXを利用するエディターにもインストールできるようになりました。([#642](https://github.com/yutotnh/wave-dash-unify/pull/642))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wave-dash-unify",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wave-dash-unify",
-      "version": "0.4.1",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wave-dash-unify",
   "displayName": "Wave Dash Unify",
   "description": "Automatically converts both FULLWIDTH TILDE and WAVE DASH characters to the WAVE DASH character",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "publisher": "yutotnh",
   "engines": {
     "vscode": "^1.66.0"


### PR DESCRIPTION
## Issue

- なし(リリース作業のためIssue起票なし)

## 対応内容

`CHANGELOG.md`の`[Unreleased]`に溜まった変更をリリースするため、バージョンを`0.4.1`から`0.5.0`(minor)に更新しました。

- `package.json` / `package-lock.json` の `version` を `0.5.0` に更新(`npm version 0.5.0 --no-git-tag-version`で更新。`package-lock.json`には偶然`0.4.1`というバージョンを持つ無関係な依存パッケージが複数あるため、一括置換ではなく`npm version`コマンドで安全に更新しています)
- `CHANGELOG.md` の `[Unreleased]` の内容を `[0.5.0] - 2026-08-04` に移動(中身は変更なし)

### バージョン種別をminorとした理由

- semver 2.0.0のPATCHは「後方互換性のあるバグ修正」に限定される定義であり、「非破壊的な変更全般」ではありません。`engines.vscode`の対応範囲を狭める変更(過去の0.4.0)は既存ユーザーが使えなくなる破壊的変更ですが、その逆に範囲を広げる変更(#661)は誰も使えなくならない一方でバグ修正でもないため、PATCHではなくMINORの受け皿に入ります。
- #661は`src/eucjp.ts`という新しいランタイムコードを追加し、新しい既知の制限事項をREADMEに文書化しており、「後方互換的に機能が追加された」というMINORの定義に合致します。0.4.0での対応範囲変更はCHANGELOGに移行手順まで明記された意図的な仕様変更であり、#661はその「バグ」を直したのではなく仕様を再拡張したものです。
- 本プロジェクトはConventional Commitsを採用しており、今回のリリースには`feat:`コミットが2件(#642, #661)含まれます。CCの標準マッピングはfeat → MINORです。

## テスト

以下をローカルで実行し、すべてパスすることを確認しました。

- `npm run lint`
- `npm run format-check`
- `npm run spellcheck`
- `npx tsc --noEmit -p .`

`npm test`(Electron版)はサンドボックス環境の制約(共有ライブラリ不足によりVS Code本体を起動できない、#627/#654と同種の既知の制約)によりローカル実行できませんでした。テスト結果はCI(3 OSマトリクス)で確認します。

## CHANGELOG

このPR自体がCHANGELOGのリリース見出し追加です(`[Unreleased]` → `[0.5.0] - 2026-08-04`、内容は変更なし)。

## 残作業

- `v0.5.0`タグの作成・pushは本PRのスコープ外です。publishはタグpush時のみ実行されるため、このPRのマージだけではVS Code Marketplace/Open VSXへの公開は行われません。