### PR TITLE
fix: releaseワークフローのトリガーをcreatedからpublishedに変更する

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -7,8 +7,10 @@ on:
     branches:
       - "main"
   release:
+    # createdはdraft releaseの作成時にも発火し、その後draftを公開してもpublishedしか
+    # 発火しないため、公開の瞬間を必ず拾えるpublishedを使う
     types:
-      - created
+      - published
 
 permissions:
   contents: write

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - "main"
   release:
-    # createdはdraft releaseの作成時にも発火し、その後draftを公開してもpublishedしか
-    # 発火しないため、公開の瞬間を必ず拾えるpublishedを使う
     types:
       - published
 


### PR DESCRIPTION
## Issue

- #702

## 対応内容

`.github/workflows/test-and-publish.yml` の `on.release.types` を `created` から `published` に変更しました。

GitHubの `release` イベントでは、draft releaseの作成は `created` として発火しますが、その後draftを公開(publish)する操作は `published` として発火し `created` は発火しません。そのため `created` だけをリッスンしていると、「draftとして作成してから後で公開する」運用でVS Code Marketplace/Open VSXへの公開(`Publish` / `Publish to Open VSX`)とGitHub Releaseへの `.vsix` 添付(`Release`)が一切実行されませんでした。

`published` は「直接公開状態で作成した場合」と「draftを後から公開した場合」の両方をカバーするため、`created` を残さず `published` のみに置き換え、二重発火を避けています。

## テスト

`v0.5.0` のリリース作業で実際にこの問題を踏み、GitHub Release本体とタグを削除して非draft状態で作り直すことでワークフローを発火させて回避しました。本PRの変更により、次回以降はdraft運用でも修正なしにワークフローが発火するはずです(このPR自体はワークフロー定義の変更のみで、実際のreleaseイベントでの動作確認は次回のリリース作業で行います)。

- `npm run format-check`
- `npm run spellcheck`

## CHANGELOG

CI/CDワークフローの内部限定の変更のため、対象外です。

## 残作業

- 次回リリース時にdraft→publishの流れで実際にワークフローが発火することを確認する