### PR TITLE
docs: CHANGELOGにアイコン最適化によるパッケージサイズ削減の記載漏れを追記する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ or each release's GitHub Releases page for those.
 - 変換処理を高速化し、大きなファイルを保存する際の遅延を大幅に軽減しました。([#627](https://github.com/yutotnh/wave-dash-unify/pull/627), [#633](https://github.com/yutotnh/wave-dash-unify/pull/633))
 - ステータスバーの文字数カウントの更新をデバウンスし、大きなファイルの編集中の負荷を軽減しました。([#632](https://github.com/yutotnh/wave-dash-unify/pull/632))
 - 対応するVS Codeの最小バージョンを1.100.0から1.66.0に引き下げ、古いVS Codeでも最新版を利用できるようにしました。0.4.0([#517](https://github.com/yutotnh/wave-dash-unify/pull/517))で必要になっていた1.100.0以降という制限を解消するもので、1.100.0以降では引き続きVS CodeのAPIでEUC-JPを判定します。([#661](https://github.com/yutotnh/wave-dash-unify/pull/661))
+- 拡張機能のアイコンを最適化し、パッケージサイズを削減しました。([#639](https://github.com/yutotnh/wave-dash-unify/pull/639))
 
 ### Fixed
 


### PR DESCRIPTION
## Issue

- なし

## 対応内容

`CHANGELOG.md` の `[0.5.0]` に、アイコン最適化(#639)によるパッケージサイズ削減の記載が漏れていたため追記しました。

#639はVSIXの約66%(28.9KB)を占めていた `doc/icon.png` を32色パレット化+可逆圧縮で5.7KB(-80%)に削減した変更で、`chore:` 接頭辞のコミットでしたが、拡張機能のダウンロード/インストールサイズに直結するユーザー向けの変更です。既に `v0.5.0` としてリリース・公開済みのため、コード変更はなくCHANGELOGの記載のみを訂正します。

## テスト

- `npm run format-check`
- `npm run spellcheck`

## CHANGELOG

このPR自体がCHANGELOGの追記です。

## 残作業

- マージ後、公開済みのGitHub Release `v0.5.0` の本文もこの追記に合わせて更新する(このPRのスコープ外、別途手動対応)